### PR TITLE
new covid example csv and component arrows size

### DIFF
--- a/packages/client/public/data/examples/covid-19.json
+++ b/packages/client/public/data/examples/covid-19.json
@@ -1,778 +1,809 @@
 {
     "primarySpecification": {
-        "causalModel": "Maximum",
-        "type": "Propensity Score Stratification"
+      "causalModel": "Maximum",
+      "type": "Propensity Score Stratification"
     },
     "confidenceInterval": true,
     "causalFactors": [
-        {
-            "description": "Patient's age group derived from the Wolfram dataset",
-            "variable": "Patient Age",
-            "column": "age_group",
-            "causes": {
-                "causeOutcome": {
-                    "causes": true,
-                    "degree": 100,
-                    "reasoning": "Older adults are likely to have higher mortality rates than younger adults"
-                },
-                "causeExposure": {
-                    "causes": true,
-                    "degree": 100,
-                    "reasoning": "Older adults are more likely to experience chronic diseases than younger adults"
-                }
-            }
-        },
-        {
-            "description": "Patient gender recorded in the Wolfram dataset",
-            "variable": "Patient Gender",
-            "column": "gender",
-            "causes": {
-                "causeOutcome": {
-                    "causes": true,
-                    "degree": 50,
-                    "reasoning": "There might be differences in risk of mortality between men and women"
-                },
-                "causeExposure": {
-                    "causes": true,
-                    "degree": 50,
-                    "reasoning": "Women tend to be more affected by long-term and chronic illness"
-                }
-            }
+      {
+        "description": "Patient's age group derived from the Wolfram dataset",
+        "variable": "Patient Age",
+        "column": "age_group",
+        "causes": {
+          "causeOutcome": {
+            "causes": true,
+            "degree": 100,
+            "reasoning": "Older adults are likely to have higher mortality rates than younger adults"
+          },
+          "causeExposure": {
+            "causes": true,
+            "degree": 100,
+            "reasoning": "Older adults are more likely to experience chronic diseases than younger adults"
+          }
         }
+      },
+      {
+        "description": "Patient gender recorded in the Wolfram dataset",
+        "variable": "Patient Gender",
+        "column": "gender",
+        "causes": {
+          "causeOutcome": {
+            "causes": true,
+            "degree": 50,
+            "reasoning": "There might be differences in risk of mortality between men and women"
+          },
+          "causeExposure": {
+            "causes": true,
+            "degree": 50,
+            "reasoning": "Women tend to be more affected by long-term and chronic illness"
+          }
+        }
+      }
     ],
     "defineQuestion": {
-        "exposure": {
-            "label": "Chronic Disease",
-            "description": "Patient presented in the Wolfram dataset who reported having a chronic disease prior to contracting COVID-19",
-            "dataset": "Wolfram dataset",
-            "definition": [
-                {
-                    "level": "Primary",
-                    "variable": "Experienced chronic disease",
-                    "description": "A binary variable indicating whether the patient reported having a chronic disease",
-                    "column": "chronic_disease"
-                }
-            ]
-        },
-        "population": {
-            "label": "Confirmed COVID-19 Cases",
-            "description": "Patients who tested positive for COVID-19 and were presented in the Wolfram's Patient Medical Data for Novel Coronavirus COVID-19 dataset",
-            "dataset": "Wolfram dataset",
-            "definition": [
-                {
-                    "level": "Primary",
-                    "variable": "Confirmed COVID-19 cases",
-                    "description": "COVID-19 patients recorded in the Wolfram dataset. Records must include complete information on the patient's age, gender, chronic disease status, and survival status",
-                    "column": "subject_inclusion"
-                }
-            ]
-        },
-        "outcome": {
-            "label": "Mortality Risk",
-            "description": "Patients did not survive after contracting COVID-19",
-            "dataset": "Wolfram dataset",
-            "definition": [
-                {
-                    "level": "Primary",
-                    "variable": "Mortality",
-                    "description": "Binary variable indicating whether the patient died after contracting COVID-19",
-                    "column": "death"
-                }
-            ]
-        },
-        "hypothesis": "Increase"
+      "exposure": {
+        "label": "Chronic Disease",
+        "description": "Patient presented in the Wolfram dataset who reported having a chronic disease prior to contracting COVID-19",
+        "dataset": "Wolfram dataset",
+        "definition": [
+          {
+            "level": "Primary",
+            "variable": "Experienced chronic disease",
+            "description": "A binary variable indicating whether the patient reported having a chronic disease",
+            "column": "chronic_disease"
+          },
+          {
+            "level": "Secondary",
+            "variable": "Experienced diabetes & hypertension chronic disease",
+            "description": "COVID-19 patients recorded in the Wolfram dataset. Records must include complete information on the patient's age, gender, chronic disease status, and survival status",
+            "column": "diabetes_hypertension"
+          }
+        ]
+      },
+      "population": {
+        "label": "Confirmed COVID-19 Cases",
+        "description": "Patients who tested positive for COVID-19 and were presented in the Wolfram's Patient Medical Data for Novel Coronavirus COVID-19 dataset",
+        "dataset": "Wolfram dataset",
+        "definition": [
+          {
+            "level": "Primary",
+            "variable": "Confirmed COVID-19 cases",
+            "description": "COVID-19 patients recorded in the Wolfram dataset. Records must include complete information on the patient's age, gender, chronic disease status, and survival status",
+            "column": "subject_inclusion"
+          }
+        ]
+      },
+      "outcome": {
+        "label": "Mortality Risk",
+        "description": "Patients did not survive after contracting COVID-19",
+        "dataset": "Wolfram dataset",
+        "definition": [
+          {
+            "level": "Primary",
+            "variable": "Mortality",
+            "description": "Binary variable indicating whether the patient died after contracting COVID-19",
+            "column": "death"
+          }
+        ]
+      },
+      "hypothesis": "Increase"
     },
     "estimators": [
-        {
-            "group": "Exposure-assignment",
-            "type": "Inverse Propensity Weighting"
-        },
-        {
-            "group": "Exposure-assignment",
-            "type": "Propensity Score Stratification"
-        },
-        {
-            "group": "Outcome-based",
-            "type": "Linear Double Machine Learning"
-        },
-        {
-            "group": "Outcome-based",
-            "type": "Linear Doubly Robust Learner"
-        },
-        {
-            "group": "Outcome-based",
-            "type": "Linear Regression"
-        }
+      {
+        "group": "Exposure-assignment",
+        "type": "Inverse Propensity Weighting"
+      },
+      {
+        "group": "Exposure-assignment",
+        "type": "Propensity Score Stratification"
+      },
+      {
+        "group": "Outcome-based",
+        "type": "Linear Double Machine Learning"
+      },
+      {
+        "group": "Outcome-based",
+        "type": "Linear Doubly Robust Learner"
+      },
+      {
+        "group": "Outcome-based",
+        "type": "Linear Regression"
+      }
     ],
     "refutations": "Quick Refutation",
     "tableColumns": [
-        {
-            "name": "age",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "ControlDefinition"
-            ]
-        },
-        {
-            "name": "age_group",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "ControlDefinition"
-            ]
-        },
-        {
-            "name": "gender",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "ControlDefinition"
-            ]
-        },
-        {
-            "name": "chronic_disease",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "ExposureDefinition"
-            ]
-        },
-        {
-            "name": "death",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "OutcomeDefinition"
-            ]
-        },
-        {
-            "name": "subject_inclusion",
-            "isDone": true,
-            "relevance": "CausallyRelevantToQuestion",
-            "relation": [
-                "PopulationDefinition"
-            ]
-        }
+      {
+        "name": "age",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["ControlDefinition"]
+      },
+      {
+        "name": "age_group",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["ControlDefinition"]
+      },
+      {
+        "name": "gender",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["ControlDefinition"]
+      },
+      {
+        "name": "chronic_disease",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["ExposureDefinition"]
+      },
+      {
+        "name": "death",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["OutcomeDefinition"]
+      },
+      {
+        "name": "subject_inclusion",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["PopulationDefinition"]
+      },
+      {
+        "name": "diabetes_hypertension",
+        "isDone": true,
+        "relevance": "CausallyRelevantToQuestion",
+        "relation": ["ExposureDefinition"]
+      }
     ],
     "modelVariables": {},
     "todoPages": [
-        "/perform/effects",
-        "/perform/estimate-distribution",
-        "/perform/evaluate"
+      "/perform/effects",
+      "/perform/estimate-distribution",
+      "/perform/evaluate"
     ],
     "tables": [
-        {
-            "url": "https://raw.githubusercontent.com/stccenter/COVID-19/master/prediction/patiant-level%20fatality/data/small%20records.csv",
-            "name": "covid19_small_data.csv",
-            "metadata": {
-                "source": "https://www.frontiersin.org/articles/10.3389/fpubh.2020.587937/full",
-                "citation": "Li, Yun, et al. (2020). Individual-level fatality prediction of COVID-19 patients using AI methods. Frontiers in Public Health 8 (2020): 566."
-            },
-            "primary": true
-        }
+      {
+        "url": "https://raw.githubusercontent.com/stccenter/COVID-19/master/prediction/patiant-level%20fatality/data/small%20records.csv",
+        "name": "covid19_small_data.csv",
+        "metadata": {
+          "source": "https://www.frontiersin.org/articles/10.3389/fpubh.2020.587937/full",
+          "citation": "Li, Yun, et al. (2020). Individual-level fatality prediction of COVID-19 patients using AI methods. Frontiers in Public Health 8 (2020): 566."
+        },
+        "primary": true
+      }
     ],
     "defaultResult": {
-        "url": "data/pre-processed-results/covid-19.csv"
+      "url": "data/pre-processed-results/covid-19.csv"
     },
     "postLoad": {
-        "steps": [
-            {
-                "type": "verb",
-                "verb": "select",
-                "input": "covid19_small_data.csv",
-                "output": "output-table-0",
-                "args": {
-                    "columns": {
-                        "age": "age",
-                        "ChronicDiseaseQ": "ChronicDiseaseQ",
-                        "gender_binary": "gender_binary",
-                        "death_binary": "death_binary"
-                    }
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "rename",
-                "input": "output-table-0",
-                "output": "output-table-1",
-                "args": {
-                    "columns": {
-                        "age": "age",
-                        "ChronicDiseaseQ": "chronic_disease",
-                        "gender_binary": "gender",
-                        "death_binary": "death"
-                    }
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-1",
-                "output": "output-table-2",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "0-6"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-2",
-                "output": "output-table-3",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "0-10"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-3",
-                "output": "output-table-4",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "1"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-4",
-                "output": "output-table-5",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "2"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-5",
-                "output": "output-table-6",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "3"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-6",
-                "output": "output-table-7",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "4"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-7",
-                "output": "output-table-8",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "5"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-8",
-                "output": "output-table-9",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "6"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-9",
-                "output": "output-table-10",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "7"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-10",
-                "output": "output-table-11",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "8"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "filter",
-                "input": "output-table-11",
-                "output": "output-table-12",
-                "args": {
-                    "column": "age",
-                    "operator": "is not equal",
-                    "type": "value",
-                    "value": "9"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-12",
-                "output": "output-table-13",
-                "args": {
-                    "to": "age_10_19",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "1"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-13",
-                "output": "output-table-14",
-                "args": {
-                    "to": "age_20_29",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "2"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-14",
-                "output": "output-table-15",
-                "args": {
-                    "to": "age_30_39",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "3"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-15",
-                "output": "output-table-16",
-                "args": {
-                    "to": "age_40_49",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "4"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-16",
-                "output": "output-table-17",
-                "args": {
-                    "to": "age_50_59",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "5"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-17",
-                "output": "output-table-18",
-                "args": {
-                    "to": "age_60_69",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "6"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-18",
-                "output": "output-table-19",
-                "args": {
-                    "to": "age_70_79",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "7"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-19",
-                "output": "output-table-20",
-                "args": {
-                    "to": "age_80_89",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "8"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "binarize",
-                "input": "output-table-20",
-                "output": "output-table-21",
-                "args": {
-                    "to": "age_90_99",
-                    "column": "age",
-                    "operator": "starts with",
-                    "type": "value",
-                    "value": "9"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-21",
-                "output": "output-table-22",
-                "args": {
-                    "to": "age_group_1",
-                    "value": "1"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-22",
-                "output": "output-table-23",
-                "args": {
-                    "to": "age_group_2",
-                    "value": "2"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-23",
-                "output": "output-table-24",
-                "args": {
-                    "to": "age_group_3",
-                    "value": "3"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-24",
-                "output": "output-table-25",
-                "args": {
-                    "to": "age_group_4",
-                    "value": "4"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-25",
-                "output": "output-table-26",
-                "args": {
-                    "to": "age_group_5",
-                    "value": "5"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-26",
-                "output": "output-table-27",
-                "args": {
-                    "to": "age_group_6",
-                    "value": "6"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-27",
-                "output": "output-table-28",
-                "args": {
-                    "to": "age_group_7",
-                    "value": "7"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-28",
-                "output": "output-table-29",
-                "args": {
-                    "to": "age_group_8",
-                    "value": "8"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-29",
-                "output": "output-table-30",
-                "args": {
-                    "to": "age_group_9",
-                    "value": "9"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-30",
-                "output": "output-table-31",
-                "args": {
-                    "to": "age_10_19",
-                    "column1": "age_10_19",
-                    "operator": "*",
-                    "column2": "age_group_1"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-31",
-                "output": "output-table-32",
-                "args": {
-                    "to": "age_20_29",
-                    "column1": "age_20_29",
-                    "operator": "*",
-                    "column2": "age_group_2"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-32",
-                "output": "output-table-33",
-                "args": {
-                    "to": "age_30_39",
-                    "column1": "age_30_39",
-                    "operator": "*",
-                    "column2": "age_group_3"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-33",
-                "output": "output-table-34",
-                "args": {
-                    "to": "age_40_49",
-                    "column1": "age_40_49",
-                    "operator": "*",
-                    "column2": "age_group_4"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-34",
-                "output": "output-table-35",
-                "args": {
-                    "to": "age_50_59",
-                    "column1": "age_50_59",
-                    "operator": "*",
-                    "column2": "age_group_5"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-35",
-                "output": "output-table-36",
-                "args": {
-                    "to": "age_60_69",
-                    "column1": "age_60_69",
-                    "operator": "*",
-                    "column2": "age_group_6"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-36",
-                "output": "output-table-37",
-                "args": {
-                    "to": "age_70_79",
-                    "column1": "age_70_79",
-                    "operator": "*",
-                    "column2": "age_group_7"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-37",
-                "output": "output-table-38",
-                "args": {
-                    "to": "age_80_89",
-                    "column1": "age_80_89",
-                    "operator": "*",
-                    "column2": "age_group_8"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-38",
-                "output": "output-table-39",
-                "args": {
-                    "to": "age_90_99",
-                    "column1": "age_90_99",
-                    "operator": "*",
-                    "column2": "age_group_9"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-39",
-                "output": "output-table-40",
-                "args": {
-                    "to": "age_10_29",
-                    "column1": "age_10_19",
-                    "operator": "+",
-                    "column2": "age_20_29"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-40",
-                "output": "output-table-41",
-                "args": {
-                    "to": "age_30_49",
-                    "column1": "age_30_39",
-                    "operator": "+",
-                    "column2": "age_40_49"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-41",
-                "output": "output-table-42",
-                "args": {
-                    "to": "age_50_69",
-                    "column1": "age_50_59",
-                    "operator": "+",
-                    "column2": "age_60_69"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-42",
-                "output": "output-table-43",
-                "args": {
-                    "to": "age_70_89",
-                    "column1": "age_70_79",
-                    "operator": "+",
-                    "column2": "age_80_89"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-43",
-                "output": "output-table-44",
-                "args": {
-                    "to": "age_10_49",
-                    "column1": "age_10_29",
-                    "operator": "+",
-                    "column2": "age_30_49"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-44",
-                "output": "output-table-45",
-                "args": {
-                    "to": "age_50_89",
-                    "column1": "age_50_69",
-                    "operator": "+",
-                    "column2": "age_70_89"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-45",
-                "output": "output-table-46",
-                "args": {
-                    "to": "age_10_89",
-                    "column1": "age_10_49",
-                    "operator": "+",
-                    "column2": "age_50_89"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "derive",
-                "input": "output-table-46",
-                "output": "output-table-47",
-                "args": {
-                    "to": "age_group",
-                    "column1": "age_10_89",
-                    "operator": "+",
-                    "column2": "age_90_99"
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "select",
-                "input": "output-table-47",
-                "output": "output-table-48",
-                "args": {
-                    "columns": {
-                        "age": "age",
-                        "chronic_disease": "chronic_disease",
-                        "gender": "gender",
-                        "death": "death",
-                        "age_group": "age_group"
-                    }
-                }
-            },
-            {
-                "type": "verb",
-                "verb": "fill",
-                "input": "output-table-48",
-                "output": "output-table-49",
-                "args": {
-                    "to": "subject_inclusion",
-                    "value": "1"
-                }
+      "steps": [
+        {
+          "type": "verb",
+          "verb": "select",
+          "input": "covid19_small_data.csv",
+          "output": "output-table-0",
+          "args": {
+            "columns": {
+              "age": "age",
+              "ChronicDiseaseQ": "ChronicDiseaseQ",
+              "gender_binary": "gender_binary",
+              "death_binary": "death_binary",
+              "hypertension": "hypertension",
+              "diabetes": "diabetes"
             }
-        ]
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "rename",
+          "input": "output-table-0",
+          "output": "output-table-1",
+          "args": {
+            "columns": {
+              "age": "age",
+              "ChronicDiseaseQ": "chronic_disease",
+              "gender_binary": "gender",
+              "death_binary": "death",
+              "hypertension": "hypertension",
+              "diabetes": "diabetes"
+            }
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-1",
+          "output": "output-table-2",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "0-6"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-2",
+          "output": "output-table-3",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "0-10"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-3",
+          "output": "output-table-4",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "1"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-4",
+          "output": "output-table-5",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "2"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-5",
+          "output": "output-table-6",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "3"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-6",
+          "output": "output-table-7",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "4"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-7",
+          "output": "output-table-8",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "5"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-8",
+          "output": "output-table-9",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "6"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-9",
+          "output": "output-table-10",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "7"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-10",
+          "output": "output-table-11",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "8"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "filter",
+          "input": "output-table-11",
+          "output": "output-table-12",
+          "args": {
+            "column": "age",
+            "operator": "is not equal",
+            "type": "value",
+            "value": "9"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-12",
+          "output": "output-table-13",
+          "args": {
+            "to": "age_10_19",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "1"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-13",
+          "output": "output-table-14",
+          "args": {
+            "to": "age_20_29",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "2"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-14",
+          "output": "output-table-15",
+          "args": {
+            "to": "age_30_39",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "3"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-15",
+          "output": "output-table-16",
+          "args": {
+            "to": "age_40_49",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "4"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-16",
+          "output": "output-table-17",
+          "args": {
+            "to": "age_50_59",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "5"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-17",
+          "output": "output-table-18",
+          "args": {
+            "to": "age_60_69",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "6"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-18",
+          "output": "output-table-19",
+          "args": {
+            "to": "age_70_79",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "7"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-19",
+          "output": "output-table-20",
+          "args": {
+            "to": "age_80_89",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "8"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-20",
+          "output": "output-table-21",
+          "args": {
+            "to": "age_90_99",
+            "column": "age",
+            "operator": "starts with",
+            "type": "value",
+            "value": "9"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-21",
+          "output": "output-table-22",
+          "args": {
+            "to": "age_group_1",
+            "value": "1"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-22",
+          "output": "output-table-23",
+          "args": {
+            "to": "age_group_2",
+            "value": "2"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-23",
+          "output": "output-table-24",
+          "args": {
+            "to": "age_group_3",
+            "value": "3"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-24",
+          "output": "output-table-25",
+          "args": {
+            "to": "age_group_4",
+            "value": "4"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-25",
+          "output": "output-table-26",
+          "args": {
+            "to": "age_group_5",
+            "value": "5"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-26",
+          "output": "output-table-27",
+          "args": {
+            "to": "age_group_6",
+            "value": "6"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-27",
+          "output": "output-table-28",
+          "args": {
+            "to": "age_group_7",
+            "value": "7"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-28",
+          "output": "output-table-29",
+          "args": {
+            "to": "age_group_8",
+            "value": "8"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-29",
+          "output": "output-table-30",
+          "args": {
+            "to": "age_group_9",
+            "value": "9"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-30",
+          "output": "output-table-31",
+          "args": {
+            "to": "age_10_19",
+            "column1": "age_10_19",
+            "operator": "*",
+            "column2": "age_group_1"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-31",
+          "output": "output-table-32",
+          "args": {
+            "to": "age_20_29",
+            "column1": "age_20_29",
+            "operator": "*",
+            "column2": "age_group_2"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-32",
+          "output": "output-table-33",
+          "args": {
+            "to": "age_30_39",
+            "column1": "age_30_39",
+            "operator": "*",
+            "column2": "age_group_3"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-33",
+          "output": "output-table-34",
+          "args": {
+            "to": "age_40_49",
+            "column1": "age_40_49",
+            "operator": "*",
+            "column2": "age_group_4"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-34",
+          "output": "output-table-35",
+          "args": {
+            "to": "age_50_59",
+            "column1": "age_50_59",
+            "operator": "*",
+            "column2": "age_group_5"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-35",
+          "output": "output-table-36",
+          "args": {
+            "to": "age_60_69",
+            "column1": "age_60_69",
+            "operator": "*",
+            "column2": "age_group_6"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-36",
+          "output": "output-table-37",
+          "args": {
+            "to": "age_70_79",
+            "column1": "age_70_79",
+            "operator": "*",
+            "column2": "age_group_7"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-37",
+          "output": "output-table-38",
+          "args": {
+            "to": "age_80_89",
+            "column1": "age_80_89",
+            "operator": "*",
+            "column2": "age_group_8"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-38",
+          "output": "output-table-39",
+          "args": {
+            "to": "age_90_99",
+            "column1": "age_90_99",
+            "operator": "*",
+            "column2": "age_group_9"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-39",
+          "output": "output-table-40",
+          "args": {
+            "to": "age_10_29",
+            "column1": "age_10_19",
+            "operator": "+",
+            "column2": "age_20_29"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-40",
+          "output": "output-table-41",
+          "args": {
+            "to": "age_30_49",
+            "column1": "age_30_39",
+            "operator": "+",
+            "column2": "age_40_49"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-41",
+          "output": "output-table-42",
+          "args": {
+            "to": "age_50_69",
+            "column1": "age_50_59",
+            "operator": "+",
+            "column2": "age_60_69"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-42",
+          "output": "output-table-43",
+          "args": {
+            "to": "age_70_89",
+            "column1": "age_70_79",
+            "operator": "+",
+            "column2": "age_80_89"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-43",
+          "output": "output-table-44",
+          "args": {
+            "to": "age_10_49",
+            "column1": "age_10_29",
+            "operator": "+",
+            "column2": "age_30_49"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-44",
+          "output": "output-table-45",
+          "args": {
+            "to": "age_50_89",
+            "column1": "age_50_69",
+            "operator": "+",
+            "column2": "age_70_89"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-45",
+          "output": "output-table-46",
+          "args": {
+            "to": "age_10_89",
+            "column1": "age_10_49",
+            "operator": "+",
+            "column2": "age_50_89"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-46",
+          "output": "output-table-47",
+          "args": {
+            "to": "age_group",
+            "column1": "age_10_89",
+            "operator": "+",
+            "column2": "age_90_99"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "derive",
+          "input": "output-table-47",
+          "output": "output-table-48",
+          "args": {
+            "column1": "diabetes",
+            "column2": "hypertension",
+            "operator": "+",
+            "to": "Combined"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "binarize",
+          "input": "output-table-48",
+          "output": "output-table-49",
+          "args": {
+            "column": "Combined",
+            "operator": ">",
+            "value": 0,
+            "type": "value",
+            "to": "diabetes_hypertension"
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "select",
+          "input": "output-table-49",
+          "output": "output-table-50",
+          "args": {
+            "columns": {
+              "age": "age",
+              "chronic_disease": "chronic_disease",
+              "gender": "gender",
+              "death": "death",
+              "age_group": "age_group",
+              "diabetes_hypertension": "diabetes_hypertension"
+            }
+          }
+        },
+        {
+          "type": "verb",
+          "verb": "fill",
+          "input": "output-table-50",
+          "output": "output-table-51",
+          "args": {
+            "to": "subject_inclusion",
+            "value": "1"
+          }
+        }
+      ]
     }
-}
+  }
+  

--- a/packages/client/src/components/CausalEffects/ComponentArrows/ComponentArrows.tsx
+++ b/packages/client/src/components/CausalEffects/ComponentArrows/ComponentArrows.tsx
@@ -29,7 +29,7 @@ export const ComponentArrows: React.FC<ComponentArrowsProps> = memo(
 			<Container size={size}>
 				<ControlsContainer>
 					<ControlsTitle size={size}>Controls</ControlsTitle>
-					<ControlsBoxContainer size={size}>
+					<DottedContainer size={size}>
 						<BoxCausalModel
 							size={size}
 							id={box1.id}
@@ -42,22 +42,26 @@ export const ComponentArrows: React.FC<ComponentArrowsProps> = memo(
 							list={outcomeDeterminants}
 							title="Outcome determinants"
 						/>
+					</DottedContainer>
+				</ControlsContainer>
+
+				<ControlsContainer>
+					<ControlsBoxContainer size={size}>
+						<BoxCausalModel
+							size={size}
+							id={box3.id}
+							title="Exposure"
+							list={[exposure]}
+						/>
+						<BoxCausalModel
+							size={size}
+							id={box4.id}
+							title="Outcome"
+							list={[outcome]}
+						/>
 					</ControlsBoxContainer>
 				</ControlsContainer>
-				<BoxCausalModel
-					size={size}
-					id={box3.id}
-					title="Exposure"
-					list={[exposure]}
-					width={50}
-				/>
-				<BoxCausalModel
-					size={size}
-					id={box4.id}
-					title="Outcome"
-					list={[outcome]}
-					width={50}
-				/>
+
 				{getArrows()}
 			</Container>
 		)
@@ -72,10 +76,10 @@ const ControlsTitle = styled.h2<{ size: Size }>`
 const Container = styled.div<{ size: Size }>`
 	background: white;
 	display: grid;
-	grid-template-rows: 3fr 1fr;
+	grid-template-rows: 2fr 1fr;
 	grid-template-columns: 1fr 1fr;
 	grid-column-gap: ${({ size }) => (size === Size.Small ? '1em' : '5em')};
-	grid-row-gap: ${({ size }) => (size === Size.Small ? '2em' : '5em')};
+	grid-row-gap: ${({ size }) => (size === Size.Small ? '0em' : '2em')};
 `
 
 const ControlsContainer = styled.div`
@@ -87,6 +91,9 @@ const ControlsBoxContainer = styled.div<{ size: Size }>`
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-column-gap: ${({ size }) => (size === Size.Small ? '3em' : '8em')};
-	border: 1px dotted black;
 	padding: 16px;
+`
+
+const DottedContainer = styled(ControlsBoxContainer)`
+	border: 1px dotted black;
 `

--- a/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/OutcomeEffectScatterplot.tsx
+++ b/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/OutcomeEffectScatterplot.tsx
@@ -121,4 +121,6 @@ const useOverlay = (data, title?: string, outcome?: string) => {
 	}, [theme, data, title, outcome, refutationLegend])
 }
 
-const Container = styled.div``
+const Container = styled.div`
+	margin-top: -15px;
+`

--- a/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/dot-plot.json
+++ b/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/dot-plot.json
@@ -193,7 +193,7 @@
 			"orient": "right",
 			"titlePadding": 34,
 			"titleFontSize": 14,
-			"labelLimit": 400,
+			"labelLimit": 200,
 			"labelFontSize": 12,
 			"labelFontWeight": {
 				"signal": "indexof(inactiveFeatures,split(datum.value,':')[1]) < 0 ? 'bold' : 'normal'"
@@ -211,6 +211,9 @@
 						"text": {
 							"signal": "split(datum.value,':')[1]"
 						}
+					},
+					"enter": {
+						"tooltip": { "signal": "split(datum.value,':')[1]" }
 					}
 				}
 			}

--- a/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/scatter-plot.json
+++ b/packages/client/src/pages/PerformAnalysis/ExploreSpecificationCurvePage/vega/scatter-plot.json
@@ -167,10 +167,19 @@
 			"scale": "x",
 			"domain": false,
 			"ticks": false,
-			"orient": "bottom",
-			"titlePadding": 5,
+			"orient": "top",
 			"title": "",
-			"labels": false
+			"titleFontSize": 13,
+			"labels": false,
+			"encode": {
+				"title": {
+					"update": {
+						"text": {
+							"signal": "'Estimated change in ' + outcome + ' by specification'"
+						}
+					}
+				}
+			}
 		},
 		{
 			"scale": "y",
@@ -179,11 +188,6 @@
 			"orient": "right"
 		}
 	],
-	"title": {
-		"text": {
-			"signal": "'Estimated change in ' + outcome + ' by specification'"
-		}
-	},
 	"marks": [
 		{
 			"name": "selectedColumn",


### PR DESCRIPTION
- add new covid example csv
- add new min label size to vega chart and tooltip with the entire name
- alternative models with the same size for all boxes