### PR TITLE
Return an empty graph if the data for DECI contains only a single column

### DIFF
--- a/python/backend/backend/discover/algorithms/deci.py
+++ b/python/backend/backend/discover/algorithms/deci.py
@@ -14,7 +14,7 @@ from networkx.readwrite import json_graph
 from pydantic import BaseModel
 
 from backend.discover.algorithms.base import CausalDiscoveryRunner, CausalGraph
-from backend.discover.base_payload import CausalDiscoveryPayload
+from backend.discover.base_payload import CausalDiscoveryPayload, get_empty_graph_json
 from backend.discover.pandas_dataset_loader import PandasDatasetLoader
 
 torch.set_default_dtype(torch.float32)
@@ -72,6 +72,11 @@ class DeciRunner(CausalDiscoveryRunner):
         self._training_options = p.training_options
 
     def do_causal_discovery(self) -> CausalGraph:
+        # if the data contains only a single column,
+        # let's return an empty graph
+        if self._prepared_data.columns.size == 1:
+            return get_empty_graph_json(self._prepared_data)
+
         dataset_loader = PandasDatasetLoader("")
         azua_dataset = dataset_loader.split_data_and_load_dataset(
             self._prepared_data, 0.5, 0, 0

--- a/python/backend/backend/discover/base_payload.py
+++ b/python/backend/backend/discover/base_payload.py
@@ -38,7 +38,7 @@ def prepare_data(func: Callable[[CausalDiscoveryPayload], Any]):
         p._prepared_data.dropna(inplace=True)
 
         if p._prepared_data.size == 0:
-            return _get_empty_graph_json(p._prepared_data)
+            return get_empty_graph_json(p._prepared_data)
 
         scaled_data = MaxAbsScaler().fit_transform(p._prepared_data)
         p._prepared_data = pd.DataFrame(
@@ -52,7 +52,7 @@ def prepare_data(func: Callable[[CausalDiscoveryPayload], Any]):
     return wrapper
 
 
-def _get_empty_graph_json(pandas_data: pd.DataFrame):
+def get_empty_graph_json(pandas_data: pd.DataFrame):
     graph = networkx.Graph()
     graph.add_nodes_from(pandas_data.columns)
     return json_graph.cytoscape_data(graph)


### PR DESCRIPTION
Fixes DECI backend returning 500 Internal Server Error only one column in the data is selected