### PR TITLE
add ability to list, flip and pin edges in causal discovery app

### DIFF
--- a/javascript/app-discover/src/components/graph/CausalEdge.tsx
+++ b/javascript/app-discover/src/components/graph/CausalEdge.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { Stack } from '@fluentui/react'
-import { memo } from 'react'
+import { memo, useCallback } from 'react'
 import type { anchorType } from 'react-xarrows'
 import Xarrow from 'react-xarrows'
 import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from 'recoil'
@@ -21,6 +21,7 @@ import type { CausalEdgeProps } from './CausalEdge.types.js'
 const LABEL_STYLE = { fontSize: '8pt', fontWeight: 'bold' }
 const CORR_REL_STYLE = { fontSize: '8pt' }
 const STACK_TOKEN_STYLE = { childrenGap: 2 }
+const DASHNESS_CORRELATION = { strokeLen: 20, nonStrokeLen: 30, animation: 0 }
 
 export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 	relationship,
@@ -32,6 +33,11 @@ export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 	const correlations =
 		useRecoilValueLoadable(FilteredCorrelationsState).valueMaybe() || []
 	const useStraightEdges = useRecoilValue(StraightEdgesState)
+
+	const onSelectEdge = useCallback(() => {
+		setSelectedObject(relationship)
+	}, [relationship])
+
 	const strokeWidth = map(
 		Math.abs(relationship.weight || 0),
 		0,
@@ -115,7 +121,7 @@ export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 						</Stack.Item>
 					</Stack>
 				}
-				passProps={{ onClick: () => setSelectedObject(relationship) }}
+				passProps={{ onClick: onSelectEdge }}
 				dashness={dashness}
 				// SVGcanvasStyle={{filter: 'blur(5px)'}}
 			/>
@@ -131,9 +137,9 @@ export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 					showHead={showArrowHead}
 					showTail={false}
 					path={path}
-					passProps={{ onClick: () => setSelectedObject(relationship) }}
+					passProps={{ onClick: onSelectEdge }}
 					key={relationship.key + '-correlation'}
-					dashness={{ strokeLen: 20, nonStrokeLen: 30, animation: 0 }}
+					dashness={DASHNESS_CORRELATION}
 					// SVGcanvasStyle={{filter: 'blur(2px)'}}
 				/>
 			)}

--- a/javascript/app-discover/src/components/graph/CausalEdge.tsx
+++ b/javascript/app-discover/src/components/graph/CausalEdge.tsx
@@ -131,6 +131,7 @@ export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 					showHead={showArrowHead}
 					showTail={false}
 					path={path}
+					passProps={{ onClick: () => setSelectedObject(relationship) }}
 					key={relationship.key + '-correlation'}
 					dashness={{ strokeLen: 20, nonStrokeLen: 30, animation: 0 }}
 					// SVGcanvasStyle={{filter: 'blur(2px)'}}
@@ -139,5 +140,3 @@ export const CausalEdge: React.FC<CausalEdgeProps> = memo(function CausalEdge({
 		</div>
 	)
 })
-
-const iconStyle = { fontSize: '8pt' }

--- a/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
+++ b/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
@@ -104,6 +104,8 @@ export const CausalGraphExplorer = memo(function CausalGraphExplorer() {
 		/>
 	))
 
+	console.log('causalRelationships', causalRelationships)
+
 	const causalEdges = causalRelationships.map(relationship => {
 		return (
 			<CausalEdge

--- a/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
+++ b/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
@@ -104,8 +104,6 @@ export const CausalGraphExplorer = memo(function CausalGraphExplorer() {
 		/>
 	))
 
-	console.log('causalRelationships', causalRelationships)
-
 	const causalEdges = causalRelationships.map(relationship => {
 		return (
 			<CausalEdge

--- a/javascript/app-discover/src/components/graph/CausalGraphNode.styles.ts
+++ b/javascript/app-discover/src/components/graph/CausalGraphNode.styles.ts
@@ -8,9 +8,7 @@ import styled from 'styled-components'
 import { containerPadding } from '../../styles/styles.js'
 
 export const NodeContainer = styled.div({
-	paddingRight: containerPadding,
 	paddingLeft: containerPadding,
-	paddingBottom: containerPadding,
 	display: 'inline-block',
 	backgroundColor: '#FFFFFF99',
 	backdropFilter: 'blur(2px)',

--- a/javascript/app-discover/src/components/graph/CausalNode.tsx
+++ b/javascript/app-discover/src/components/graph/CausalNode.tsx
@@ -3,10 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { Label, Stack } from '@fluentui/react'
-import {
-	CirclePlusIcon,
-	StatusCircleErrorXIcon,
-} from '@fluentui/react-icons-mdl2'
 import isEqual from 'lodash-es/isEqual'
 import { memo, useCallback } from 'react'
 import { useRecoilState } from 'recoil'
@@ -16,6 +12,7 @@ import {
 	InModelCausalVariablesState,
 	SelectedObjectState,
 } from '../../state/index.jsx'
+import { IconButtonDark } from '../../styles/styles.js'
 import { useIsVariableInModel } from './CausalNode.hooks.js'
 import type { CausalNodeProps } from './CausalNode.types.js'
 
@@ -59,12 +56,19 @@ export const CausalNode: React.FC<CausalNodeProps> = memo(function CausalNode({
 	}
 
 	return (
-		<Stack className={className} grow horizontal tokens={{ childrenGap: 5 }}>
+		<Stack
+			className={className}
+			verticalAlign="center"
+			grow
+			horizontal
+			tokens={{ childrenGap: 5 }}
+		>
 			<Stack.Item align="center" grow onClick={selectVariable}>
 				<Label
 					disabled={!isInModel}
 					style={{
 						textAlign: center ? 'center' : undefined,
+						overflow: 'hidden',
 					}}
 				>
 					{variable.name}
@@ -72,14 +76,19 @@ export const CausalNode: React.FC<CausalNodeProps> = memo(function CausalNode({
 			</Stack.Item>
 			{isAddable && !isInModel && (
 				<Stack.Item align="center">
-					<CirclePlusIcon onClick={addToModel} />
+					<IconButtonDark onClick={addToModel} iconProps={icons.add} />
 				</Stack.Item>
 			)}
 			{isRemovable && isInModel && (
-				<Stack.Item align="center" onClick={removeFromModel}>
-					<StatusCircleErrorXIcon />
+				<Stack.Item align="center">
+					<IconButtonDark onClick={removeFromModel} iconProps={icons.remove} />
 				</Stack.Item>
 			)}
 		</Stack>
 	)
 })
+
+const icons = {
+	remove: { iconName: 'StatusCircleErrorX' },
+	add: { iconName: 'circlePlus' },
+}

--- a/javascript/app-discover/src/components/graph/CausalNode.tsx
+++ b/javascript/app-discover/src/components/graph/CausalNode.tsx
@@ -16,6 +16,7 @@ import { IconButtonDark } from '../../styles/styles.js'
 import { useIsVariableInModel } from './CausalNode.hooks.js'
 import type { CausalNodeProps } from './CausalNode.types.js'
 
+const childrenGap = 5
 export const CausalNode: React.FC<CausalNodeProps> = memo(function CausalNode({
 	variable,
 	className,
@@ -61,7 +62,7 @@ export const CausalNode: React.FC<CausalNodeProps> = memo(function CausalNode({
 			verticalAlign="center"
 			grow
 			horizontal
-			tokens={{ childrenGap: 5 }}
+			tokens={{ childrenGap }}
 		>
 			<Stack.Item align="center" grow onClick={selectVariable}>
 				<Label

--- a/javascript/app-discover/src/components/lists/EdgeItem.styles.ts
+++ b/javascript/app-discover/src/components/lists/EdgeItem.styles.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import styled from 'styled-components'
+
+export const Container = styled.div``
+
+export const icons = {
+	delete: { iconName: 'Delete' },
+	pin: { iconName: 'Pin' },
+	switch: { iconName: 'Switch' },
+	pinned: { iconName: 'PinSolid12' },
+}

--- a/javascript/app-discover/src/components/lists/EdgeItem.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeItem.tsx
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { IconButton, Stack, Text } from '@fluentui/react'
+import { memo } from 'react'
+import styled from 'styled-components'
+
+import { ManualRelationshipReason } from '../../domain/Relationship.js'
+import type { EdgeItemProps } from './EdgeItem.types.js'
+
+export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
+	relationship,
+	columnName,
+	onFlip,
+	onRemove,
+	onPin,
+	onSelect,
+}) {
+	return (
+		<RelationshipContainer>
+			<Stack
+				horizontal
+				horizontalAlign="space-between"
+				tokens={{ childrenGap: 5 }}
+				verticalAlign="center"
+			>
+				<Stack.Item>
+					<Text
+						style={{ cursor: 'pointer' }}
+						onClick={() => onSelect(relationship)}
+					>
+						{columnName}
+					</Text>
+				</Stack.Item>
+				<Stack.Item>
+					<Stack
+						horizontal
+						horizontalAlign="space-between"
+						tokens={{ childrenGap: 5 }}
+						verticalAlign="center"
+					>
+						<Stack.Item>
+							<Text variant={'tiny'}>{relationship?.weight?.toFixed(2)}</Text>
+						</Stack.Item>
+						<Stack.Item align="center">
+							<IconButton
+								toggle
+								checked={
+									relationship.reason === ManualRelationshipReason.Pinned
+								}
+								iconProps={
+									relationship.reason === ManualRelationshipReason.Pinned
+										? icons.pinned
+										: icons.pin
+								}
+								onClick={() => onPin(relationship)}
+							/>
+						</Stack.Item>
+						<Stack.Item align="center">
+							<IconButton
+								iconProps={icons.switch}
+								onClick={() => onFlip(relationship)}
+							/>
+						</Stack.Item>
+						<Stack.Item align="center">
+							<IconButton
+								iconProps={icons.delete}
+								onClick={() => onRemove(relationship)}
+							/>
+						</Stack.Item>
+					</Stack>
+				</Stack.Item>
+			</Stack>
+		</RelationshipContainer>
+	)
+})
+
+const RelationshipContainer = styled.div``
+
+const icons = {
+	delete: { iconName: 'Delete' },
+	pin: { iconName: 'Pin' },
+	switch: { iconName: 'Switch' },
+	pinned: { iconName: 'PinSolid12' },
+}

--- a/javascript/app-discover/src/components/lists/EdgeItem.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeItem.tsx
@@ -5,7 +5,10 @@
 import { Stack, Text, TooltipHost } from '@fluentui/react'
 import { memo } from 'react'
 
-import { ManualRelationshipReason } from '../../domain/Relationship.js'
+import {
+	hasSameReason,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
 import { IconButtonDark } from '../../styles/styles.js'
 import { Container, icons } from './EdgeItem.styles.js'
 import type { EdgeItemProps } from './EdgeItem.types.js'
@@ -48,18 +51,19 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 						<Stack.Item align="center">
 							<TooltipHost
 								content={
-									constraint?.reason === ManualRelationshipReason.Pinned
+									hasSameReason(ManualRelationshipReason.Pinned, constraint)
 										? 'Relationship confirmed as relevant by the user. Click to undo it'
 										: 'Confirm as relevant relationship'
 								}
 							>
 								<IconButtonDark
 									toggle
-									checked={
-										constraint?.reason === ManualRelationshipReason.Pinned
-									}
+									checked={hasSameReason(
+										ManualRelationshipReason.Pinned,
+										constraint,
+									)}
 									iconProps={
-										constraint?.reason === ManualRelationshipReason.Pinned
+										hasSameReason(ManualRelationshipReason.Pinned, constraint)
 											? icons.pinned
 											: icons.pin
 									}
@@ -70,16 +74,17 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 						<Stack.Item align="center">
 							<TooltipHost
 								content={
-									constraint?.reason === ManualRelationshipReason.Flipped
+									hasSameReason(ManualRelationshipReason.Flipped, constraint)
 										? 'Relationship manually reversed by the user. Click to undo it'
 										: 'Manually reverse direction of relationship'
 								}
 							>
 								<IconButtonDark
 									toggle
-									checked={
-										constraint?.reason === ManualRelationshipReason.Flipped
-									}
+									checked={hasSameReason(
+										ManualRelationshipReason.Flipped,
+										constraint,
+									)}
 									iconProps={icons.switch}
 									onClick={() => onFlip(relationship)}
 								/>

--- a/javascript/app-discover/src/components/lists/EdgeItem.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeItem.tsx
@@ -13,6 +13,8 @@ import { IconButtonDark } from '../../styles/styles.js'
 import { Container, icons } from './EdgeItem.styles.js'
 import type { EdgeItemProps } from './EdgeItem.types.js'
 
+const childrenGap = 5
+const cursor = 'pointer'
 export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 	relationship,
 	columnName,
@@ -27,14 +29,11 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 			<Stack
 				horizontal
 				horizontalAlign="space-between"
-				tokens={{ childrenGap: 5 }}
+				tokens={{ childrenGap }}
 				verticalAlign="center"
 			>
 				<Stack.Item>
-					<Text
-						style={{ cursor: 'pointer' }}
-						onClick={() => onSelect(relationship)}
-					>
+					<Text style={{ cursor }} onClick={() => onSelect(relationship)}>
 						{columnName}
 					</Text>
 				</Stack.Item>
@@ -42,7 +41,7 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 					<Stack
 						horizontal
 						horizontalAlign="space-between"
-						tokens={{ childrenGap: 5 }}
+						tokens={{ childrenGap }}
 						verticalAlign="center"
 					>
 						<Stack.Item>
@@ -52,8 +51,8 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 							<TooltipHost
 								content={
 									hasSameReason(ManualRelationshipReason.Pinned, constraint)
-										? 'Relationship confirmed as relevant by the user. Click to undo it'
-										: 'Confirm as relevant relationship'
+										? 'Relationship confirmed as relevant. Click to undo'
+										: 'Confirm relationship as relevant'
 								}
 							>
 								<IconButtonDark
@@ -79,7 +78,7 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 							<TooltipHost
 								content={
 									hasSameReason(ManualRelationshipReason.Flipped, constraint)
-										? 'Relationship manually reversed by the user. Click to undo it'
+										? 'Relationship manually reversed. Click to undo it'
 										: 'Manually reverse direction of relationship'
 								}
 							>

--- a/javascript/app-discover/src/components/lists/EdgeItem.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeItem.tsx
@@ -62,6 +62,10 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 										ManualRelationshipReason.Pinned,
 										constraint,
 									)}
+									disabled={hasSameReason(
+										ManualRelationshipReason.Flipped,
+										constraint,
+									)}
 									iconProps={
 										hasSameReason(ManualRelationshipReason.Pinned, constraint)
 											? icons.pinned
@@ -81,6 +85,10 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 							>
 								<IconButtonDark
 									toggle
+									disabled={hasSameReason(
+										ManualRelationshipReason.Pinned,
+										constraint,
+									)}
 									checked={hasSameReason(
 										ManualRelationshipReason.Flipped,
 										constraint,

--- a/javascript/app-discover/src/components/lists/EdgeItem.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeItem.tsx
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { IconButton, Stack, Text } from '@fluentui/react'
+import { Stack, Text, TooltipHost } from '@fluentui/react'
 import { memo } from 'react'
-import styled from 'styled-components'
 
 import { ManualRelationshipReason } from '../../domain/Relationship.js'
+import { IconButtonDark } from '../../styles/styles.js'
+import { Container, icons } from './EdgeItem.styles.js'
 import type { EdgeItemProps } from './EdgeItem.types.js'
 
 export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
@@ -16,9 +17,10 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 	onRemove,
 	onPin,
 	onSelect,
+	constraint,
 }) {
 	return (
-		<RelationshipContainer>
+		<Container>
 			<Stack
 				horizontal
 				horizontalAlign="space-between"
@@ -44,43 +46,56 @@ export const EdgeItem: React.FC<EdgeItemProps> = memo(function EdgeItem({
 							<Text variant={'tiny'}>{relationship?.weight?.toFixed(2)}</Text>
 						</Stack.Item>
 						<Stack.Item align="center">
-							<IconButton
-								toggle
-								checked={
-									relationship.reason === ManualRelationshipReason.Pinned
+							<TooltipHost
+								content={
+									constraint?.reason === ManualRelationshipReason.Pinned
+										? 'Relationship confirmed as relevant by the user. Click to undo it'
+										: 'Confirm as relevant relationship'
 								}
-								iconProps={
-									relationship.reason === ManualRelationshipReason.Pinned
-										? icons.pinned
-										: icons.pin
-								}
-								onClick={() => onPin(relationship)}
-							/>
+							>
+								<IconButtonDark
+									toggle
+									checked={
+										constraint?.reason === ManualRelationshipReason.Pinned
+									}
+									iconProps={
+										constraint?.reason === ManualRelationshipReason.Pinned
+											? icons.pinned
+											: icons.pin
+									}
+									onClick={() => onPin(relationship)}
+								/>
+							</TooltipHost>
 						</Stack.Item>
 						<Stack.Item align="center">
-							<IconButton
-								iconProps={icons.switch}
-								onClick={() => onFlip(relationship)}
-							/>
+							<TooltipHost
+								content={
+									constraint?.reason === ManualRelationshipReason.Flipped
+										? 'Relationship manually reversed by the user. Click to undo it'
+										: 'Manually reverse direction of relationship'
+								}
+							>
+								<IconButtonDark
+									toggle
+									checked={
+										constraint?.reason === ManualRelationshipReason.Flipped
+									}
+									iconProps={icons.switch}
+									onClick={() => onFlip(relationship)}
+								/>
+							</TooltipHost>
 						</Stack.Item>
 						<Stack.Item align="center">
-							<IconButton
-								iconProps={icons.delete}
-								onClick={() => onRemove(relationship)}
-							/>
+							<TooltipHost content="Remove relationship">
+								<IconButtonDark
+									iconProps={icons.delete}
+									onClick={() => onRemove(relationship)}
+								/>
+							</TooltipHost>
 						</Stack.Item>
 					</Stack>
 				</Stack.Item>
 			</Stack>
-		</RelationshipContainer>
+		</Container>
 	)
 })
-
-const RelationshipContainer = styled.div``
-
-const icons = {
-	delete: { iconName: 'Delete' },
-	pin: { iconName: 'Pin' },
-	switch: { iconName: 'Switch' },
-	pinned: { iconName: 'PinSolid12' },
-}

--- a/javascript/app-discover/src/components/lists/EdgeItem.types.ts
+++ b/javascript/app-discover/src/components/lists/EdgeItem.types.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import type { Relationship } from '../../domain/Relationship.jsx'
+
+export interface EdgeItemProps {
+	relationship: Relationship
+	columnName: string
+	onFlip: (relationship: Relationship) => void
+	onRemove: (relationship: Relationship) => void
+	onPin: (relationship: Relationship) => void
+	onSelect: (relationship: Relationship) => void
+}

--- a/javascript/app-discover/src/components/lists/EdgeItem.types.ts
+++ b/javascript/app-discover/src/components/lists/EdgeItem.types.ts
@@ -11,4 +11,5 @@ export interface EdgeItemProps {
 	onRemove: (relationship: Relationship) => void
 	onPin: (relationship: Relationship) => void
 	onSelect: (relationship: Relationship) => void
+	constraint?: Relationship
 }

--- a/javascript/app-discover/src/components/lists/EdgeList.hooks.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeList.hooks.tsx
@@ -1,0 +1,113 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { useCallback } from 'react'
+import type { SetterOrUpdater } from 'recoil'
+
+import type { CausalDiscoveryConstraints } from '../../domain/CausalDiscovery/CausalDiscoveryConstraints.js'
+import type { VariableReference } from '../../domain/CausalVariable.js'
+import type { Relationship } from '../../domain/Relationship.js'
+import {
+	hasSameSourceAndTarget,
+	involvesVariable,
+} from '../../domain/Relationship.js'
+import type { CausalVariable } from './../../domain/CausalVariable.js'
+import { EdgeItem } from './EdgeItem.js'
+import { pinEdge, removeEdge } from './EdgeList.utils.js'
+
+export function useOnFlip(
+	generalConstraintsCauses: VariableReference[],
+	setRelationshipOption: (relationship: Relationship) => void,
+	toggleDialogConfirm: () => void,
+	onUpdateFlippedConstraint: (relationship: Relationship) => void,
+): (relationship: Relationship) => void {
+	return useCallback(
+		(relationship: Relationship) => {
+			if (
+				generalConstraintsCauses.find(x => involvesVariable(relationship, x))
+			) {
+				setRelationshipOption(relationship)
+				return toggleDialogConfirm()
+			}
+			onUpdateFlippedConstraint(relationship)
+		},
+		[
+			onUpdateFlippedConstraint,
+			toggleDialogConfirm,
+			setRelationshipOption,
+			generalConstraintsCauses,
+		],
+	)
+}
+
+export function useOnPin(
+	constraints: CausalDiscoveryConstraints,
+	onUpdateConstraints: SetterOrUpdater<CausalDiscoveryConstraints>,
+): (relationship: Relationship) => void {
+	return useCallback(
+		(relationship: Relationship) => {
+			pinEdge(constraints, onUpdateConstraints, relationship)
+		},
+		[onUpdateConstraints, constraints],
+	)
+}
+export function useOnRemove(
+	constraints: CausalDiscoveryConstraints,
+	onUpdateConstraints: SetterOrUpdater<CausalDiscoveryConstraints>,
+): (relationship: Relationship) => void {
+	return useCallback(
+		(relationship: Relationship) => {
+			removeEdge(constraints, onUpdateConstraints, relationship)
+		},
+		[constraints, onUpdateConstraints],
+	)
+}
+
+export function useOnRenderItem(
+	onSelect: (relationship: Relationship) => void,
+	onFlip: (relationship: Relationship) => void,
+	onPin: (relationship: Relationship) => void,
+	onRemove: (relationship: Relationship) => void,
+	variable: CausalVariable,
+	constraints: CausalDiscoveryConstraints,
+): (relationship: Relationship) => JSX.Element | undefined {
+	return useCallback(
+		(relationship: Relationship) => {
+			if (!relationship) return undefined
+			return (
+				<EdgeItem
+					key={relationship.key}
+					relationship={relationship}
+					onFlip={onFlip}
+					onRemove={onRemove}
+					onPin={onPin}
+					onSelect={onSelect}
+					columnName={
+						variable.columnName === relationship.source.columnName
+							? relationship.target.columnName
+							: relationship.source.columnName
+					}
+					constraint={constraints?.manualRelationships?.find(x =>
+						hasSameSourceAndTarget(x, relationship),
+					)}
+				/>
+			)
+		},
+		[onSelect, onFlip, onPin, onRemove, variable, constraints],
+	)
+}
+
+export function useOnConfirmFlip(
+	onUpdateFlippedConstraint: (relationshipOption: Relationship) => void,
+	relationshipOption: Relationship | undefined,
+): () => void {
+	return useCallback(() => {
+		if (!relationshipOption) return
+		onUpdateFlippedConstraint(relationshipOption)
+	}, [relationshipOption, onUpdateFlippedConstraint])
+}

--- a/javascript/app-discover/src/components/lists/EdgeList.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeList.tsx
@@ -117,10 +117,10 @@ export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 			></DialogConfirm>
 			{Object.keys(groupedList).map(groupName => {
 				return (
-					<>
+					<div key={groupName}>
 						<Label>{groupName}</Label>
 						{groupedList[groupName].map(r => renderItem(r))}
-					</>
+					</div>
 				)
 			})}
 		</FocusZone>

--- a/javascript/app-discover/src/components/lists/EdgeList.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeList.tsx
@@ -1,0 +1,131 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { FocusZone, Label } from '@fluentui/react'
+import { memo, useCallback } from 'react'
+import { useRecoilState } from 'recoil'
+
+import {
+	type Relationship,
+	invertRelationship,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
+import { CausalGraphConstraintsState } from '../../state/index.js'
+import { EdgeItem } from './EdgeItem.js'
+import type { EdgeListProps } from './EdgeList.types.js'
+
+export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
+	relationships,
+	variable,
+	onSelect,
+}) {
+	const [constraints, setConstraints] = useRecoilState(
+		CausalGraphConstraintsState,
+	)
+
+	const onFlip = useCallback(
+		(relationship: Relationship) => {
+			const existingRelationships = constraints.forbiddenRelationships.filter(
+				x => x.target.columnName !== relationship.source.columnName,
+			)
+			const newConstraints = {
+				...constraints,
+				forbiddenRelationships: [
+					...existingRelationships,
+					{
+						...relationship,
+						reason: ManualRelationshipReason.Flipped,
+					},
+				],
+			}
+			setConstraints(newConstraints)
+		},
+		[setConstraints, constraints],
+	)
+
+	const onPin = useCallback(
+		(relationship: Relationship) => {
+			const reverse = invertRelationship(relationship)
+			reverse.reason = ManualRelationshipReason.Pinned
+			const newConstraints = {
+				...constraints,
+				forbiddenRelationships: [
+					...constraints.forbiddenRelationships,
+					reverse,
+				],
+			}
+			setConstraints(newConstraints)
+		},
+		[setConstraints, constraints],
+	)
+
+	const onRemove = useCallback(
+		(relationship: Relationship) => {
+			const newConstraints = {
+				...constraints,
+				forbiddenRelationships: [
+					...constraints.forbiddenRelationships,
+					{
+						...relationship,
+						reason: ManualRelationshipReason.Removed,
+					},
+				],
+			}
+			setConstraints(newConstraints)
+		},
+		[setConstraints, constraints],
+	)
+
+	const renderItem = useCallback(
+		(relationship: Relationship, columnName: string) => (
+			<EdgeItem
+				key={relationship.key}
+				relationship={relationship}
+				onFlip={onFlip}
+				onRemove={onRemove}
+				onPin={onPin}
+				onSelect={onSelect}
+				columnName={columnName}
+			/>
+		),
+		[onSelect, onFlip, onPin, onRemove],
+	)
+
+	const increases = relationships?.flatMap(r => {
+		const yes =
+			(r?.weight || 0) > 0 && r.source.columnName === variable.columnName
+		return yes ? renderItem(r, r.target.columnName) : []
+	})
+
+	const decreases = relationships?.flatMap(r => {
+		const yes =
+			(r?.weight || 0) < 0 && r.source.columnName === variable.columnName
+		return yes ? renderItem(r, r.target.columnName) : []
+	})
+
+	const isIncreasedBy = relationships?.flatMap(r => {
+		const yes =
+			(r?.weight || 0) > 0 && r.target.columnName === variable.columnName
+		return yes ? renderItem(r, r.source.columnName) : []
+	})
+
+	const isDecreasedBy = relationships?.flatMap(r => {
+		const yes =
+			(r?.weight || 0) < 0 && r.target.columnName === variable.columnName
+		return yes ? renderItem(r, r.source.columnName) : []
+	})
+
+	return (
+		<FocusZone>
+			{!!increases.length && <Label>Increases:</Label>}
+			{increases}
+			{!!decreases.length && <Label>Decreases:</Label>}
+			{decreases}
+			{!!isIncreasedBy.length && <Label>Is increased by:</Label>}
+			{isIncreasedBy}
+			{!!isDecreasedBy.length && <Label>Is decreased by:</Label>}
+			{isDecreasedBy}
+		</FocusZone>
+	)
+})

--- a/javascript/app-discover/src/components/lists/EdgeList.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeList.tsx
@@ -10,11 +10,15 @@ import { memo, useCallback, useState } from 'react'
 import {
 	type Relationship,
 	hasSameSourceAndTarget,
-	invertRelationship,
-	ManualRelationshipReason,
 } from '../../domain/Relationship.js'
 import { EdgeItem } from './EdgeItem.js'
 import type { EdgeListProps } from './EdgeList.types.js'
+import {
+	flipEdge,
+	groupByEffectType,
+	pinEdge,
+	removeEdge,
+} from './EdgeList.utils.js'
 
 export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 	relationships,
@@ -23,50 +27,24 @@ export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 	constraints,
 	onUpdateConstraints,
 }) {
+	const groupedList = groupByEffectType(relationships, variable.columnName)
 	const [
 		showDialogConfirm,
 		{ toggle: toggleDialogConfirm, setFalse: closeDialogConfirm },
 	] = useBoolean(false)
-	const causes = constraints.causes.concat(constraints.effects)
 	const [relationshipOption, setRelationshipOption] = useState<Relationship>()
+	const generalConstraintsCauses = constraints.causes.concat(
+		constraints.effects,
+	)
 
 	const onUpdateFlippedConstraint = useCallback(
 		(relationship?: Relationship) => {
-			if (!relationship) return
-			const columns = [
-				relationship.source.columnName,
-				relationship.target.columnName,
-			]
-			const reverse = invertRelationship(relationship)
-			const existingRelationships = [...constraints.manualRelationships]
-			const newConstraints = {
-				causes: constraints.causes.filter(x => !columns.includes(x.columnName)),
-				effects: constraints.effects.filter(
-					x => !columns.includes(x.columnName),
-				),
-				manualRelationships: constraints.manualRelationships.find(
-					x =>
-						hasSameSourceAndTarget(x, relationship) &&
-						x.reason === ManualRelationshipReason.Flipped,
-				)
-					? existingRelationships.filter(
-							x =>
-								!(
-									hasSameSourceAndTarget(x, relationship) &&
-									x.reason === ManualRelationshipReason.Flipped
-								),
-					  )
-					: [
-							...existingRelationships,
-							{
-								...reverse,
-								reason: ManualRelationshipReason.Flipped,
-							},
-					  ],
-			}
-
-			onUpdateConstraints(newConstraints)
-			closeDialogConfirm()
+			flipEdge(
+				constraints,
+				onUpdateConstraints,
+				closeDialogConfirm,
+				relationship,
+			)
 		},
 		[closeDialogConfirm, onUpdateConstraints, constraints],
 	)
@@ -74,115 +52,59 @@ export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 	const onFlip = useCallback(
 		(relationship: Relationship) => {
 			if (
-				causes.find(x => x.columnName === relationship.source.columnName) ||
-				causes.find(x => x.columnName === relationship.target.columnName)
+				generalConstraintsCauses.find(
+					x => x.columnName === relationship.source.columnName,
+				) ||
+				generalConstraintsCauses.find(
+					x => x.columnName === relationship.target.columnName,
+				)
 			) {
 				setRelationshipOption(relationship)
 				return toggleDialogConfirm()
 			}
 			onUpdateFlippedConstraint(relationship)
 		},
-		[onUpdateFlippedConstraint, toggleDialogConfirm, causes],
+		[onUpdateFlippedConstraint, toggleDialogConfirm, generalConstraintsCauses],
 	)
 
 	const onPin = useCallback(
 		(relationship: Relationship) => {
-			let newConstraints = {
-				...constraints,
-				manualRelationships: [
-					...constraints.manualRelationships,
-					{
-						...relationship,
-						reason: ManualRelationshipReason.Pinned,
-					},
-				],
-			}
-			if (
-				constraints.manualRelationships.find(x => x.key === relationship.key)
-			) {
-				newConstraints = {
-					...constraints,
-					manualRelationships: [
-						...constraints.manualRelationships.filter(
-							x => x.key !== relationship.key,
-						),
-					],
-				}
-			}
-
-			onUpdateConstraints(newConstraints)
+			pinEdge(constraints, onUpdateConstraints, relationship)
 		},
 		[onUpdateConstraints, constraints],
 	)
 
 	const onRemove = useCallback(
 		(relationship: Relationship) => {
-			const newConstraints = {
-				...constraints,
-				manualRelationships: [
-					...constraints.manualRelationships,
-					{
-						...relationship,
-						reason: ManualRelationshipReason.Removed,
-					},
-				],
-			}
-			onUpdateConstraints(newConstraints)
+			removeEdge(constraints, onUpdateConstraints, relationship)
 		},
-		[onUpdateConstraints, constraints],
+		[constraints, onUpdateConstraints],
 	)
 
 	const renderItem = useCallback(
-		(relationship: Relationship, columnName: string) => (
-			<EdgeItem
-				key={relationship.key}
-				relationship={relationship}
-				onFlip={onFlip}
-				onRemove={onRemove}
-				onPin={onPin}
-				onSelect={onSelect}
-				columnName={columnName}
-				constraint={constraints?.manualRelationships?.find(x =>
-					hasSameSourceAndTarget(x, relationship),
-				)}
-			/>
-		),
-		[onSelect, onFlip, onPin, onRemove, constraints],
+		(relationship: Relationship) => {
+			if (!relationship) return undefined
+			return (
+				<EdgeItem
+					key={relationship.key}
+					relationship={relationship}
+					onFlip={onFlip}
+					onRemove={onRemove}
+					onPin={onPin}
+					onSelect={onSelect}
+					columnName={
+						variable.columnName === relationship.source.columnName
+							? relationship.target.columnName
+							: relationship.source.columnName
+					}
+					constraint={constraints?.manualRelationships?.find(x =>
+						hasSameSourceAndTarget(x, relationship),
+					)}
+				/>
+			)
+		},
+		[onSelect, onFlip, onPin, onRemove, variable, constraints],
 	)
-
-	const increases = relationships?.flatMap(r => {
-		const yes =
-			(r?.weight || 0) > 0 && r.source.columnName === variable.columnName
-		return yes ? renderItem(r, r.target.columnName) : []
-	})
-
-	const decreases = relationships?.flatMap(r => {
-		const yes =
-			(r?.weight || 0) < 0 && r.source.columnName === variable.columnName
-		return yes ? renderItem(r, r.target.columnName) : []
-	})
-
-	const isIncreasedBy = relationships?.flatMap(r => {
-		const yes =
-			(r?.weight || 0) > 0 && r.target.columnName === variable.columnName
-		return yes ? renderItem(r, r.source.columnName) : []
-	})
-
-	const isDecreasedBy = relationships?.flatMap(r => {
-		const yes =
-			(r?.weight || 0) < 0 && r.target.columnName === variable.columnName
-		return yes ? renderItem(r, r.source.columnName) : []
-	})
-	const affects = relationships?.flatMap(r => {
-		const yes =
-			r?.weight === undefined && r.source.columnName === variable.columnName
-		return yes ? renderItem(r, r.target.columnName) : []
-	})
-	const isAffectedBy = relationships?.flatMap(r => {
-		const yes =
-			r?.weight === undefined && r.target.columnName === variable.columnName
-		return yes ? renderItem(r, r.source.columnName) : []
-	})
 
 	return (
 		<FocusZone>
@@ -193,18 +115,14 @@ export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 				title="Are you sure you want to proceed?"
 				subText="Setting this constraint will remove any manual edges you pinned or flipped for this variable"
 			></DialogConfirm>
-			{!!increases.length && <Label>Increases:</Label>}
-			{increases}
-			{!!decreases.length && <Label>Decreases:</Label>}
-			{decreases}
-			{!!isIncreasedBy.length && <Label>Is increased by:</Label>}
-			{isIncreasedBy}
-			{!!isDecreasedBy.length && <Label>Is decreased by:</Label>}
-			{isDecreasedBy}
-			{!!affects.length && <Label>Affects:</Label>}
-			{affects}
-			{!!isAffectedBy.length && <Label>Is affected by:</Label>}
-			{isAffectedBy}
+			{Object.keys(groupedList).map(groupName => {
+				return (
+					<>
+						<Label>{groupName}</Label>
+						{groupedList[groupName].map(r => renderItem(r))}
+					</>
+				)
+			})}
 		</FocusZone>
 	)
 })

--- a/javascript/app-discover/src/components/lists/EdgeList.tsx
+++ b/javascript/app-discover/src/components/lists/EdgeList.tsx
@@ -7,18 +7,16 @@ import { FocusZone, Label } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 import { memo, useCallback, useState } from 'react'
 
+import { type Relationship } from '../../domain/Relationship.js'
 import {
-	type Relationship,
-	hasSameSourceAndTarget,
-} from '../../domain/Relationship.js'
-import { EdgeItem } from './EdgeItem.js'
+	useOnConfirmFlip,
+	useOnFlip,
+	useOnPin,
+	useOnRemove,
+	useOnRenderItem,
+} from './EdgeList.hooks.js'
 import type { EdgeListProps } from './EdgeList.types.js'
-import {
-	flipEdge,
-	groupByEffectType,
-	pinEdge,
-	removeEdge,
-} from './EdgeList.utils.js'
+import { flipEdge, groupByEffectType } from './EdgeList.utils.js'
 
 export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 	relationships,
@@ -49,67 +47,34 @@ export const EdgeList: React.FC<EdgeListProps> = memo(function EdgeList({
 		[closeDialogConfirm, onUpdateConstraints, constraints],
 	)
 
-	const onFlip = useCallback(
-		(relationship: Relationship) => {
-			if (
-				generalConstraintsCauses.find(
-					x => x.columnName === relationship.source.columnName,
-				) ||
-				generalConstraintsCauses.find(
-					x => x.columnName === relationship.target.columnName,
-				)
-			) {
-				setRelationshipOption(relationship)
-				return toggleDialogConfirm()
-			}
-			onUpdateFlippedConstraint(relationship)
-		},
-		[onUpdateFlippedConstraint, toggleDialogConfirm, generalConstraintsCauses],
+	const onFlip = useOnFlip(
+		generalConstraintsCauses,
+		setRelationshipOption,
+		toggleDialogConfirm,
+		onUpdateFlippedConstraint,
 	)
 
-	const onPin = useCallback(
-		(relationship: Relationship) => {
-			pinEdge(constraints, onUpdateConstraints, relationship)
-		},
-		[onUpdateConstraints, constraints],
+	const onPin = useOnPin(constraints, onUpdateConstraints)
+	const onRemove = useOnRemove(constraints, onUpdateConstraints)
+
+	const renderItem = useOnRenderItem(
+		onSelect,
+		onFlip,
+		onPin,
+		onRemove,
+		variable,
+		constraints,
 	)
 
-	const onRemove = useCallback(
-		(relationship: Relationship) => {
-			removeEdge(constraints, onUpdateConstraints, relationship)
-		},
-		[constraints, onUpdateConstraints],
-	)
-
-	const renderItem = useCallback(
-		(relationship: Relationship) => {
-			if (!relationship) return undefined
-			return (
-				<EdgeItem
-					key={relationship.key}
-					relationship={relationship}
-					onFlip={onFlip}
-					onRemove={onRemove}
-					onPin={onPin}
-					onSelect={onSelect}
-					columnName={
-						variable.columnName === relationship.source.columnName
-							? relationship.target.columnName
-							: relationship.source.columnName
-					}
-					constraint={constraints?.manualRelationships?.find(x =>
-						hasSameSourceAndTarget(x, relationship),
-					)}
-				/>
-			)
-		},
-		[onSelect, onFlip, onPin, onRemove, variable, constraints],
+	const onConfirmFlip = useOnConfirmFlip(
+		onUpdateFlippedConstraint,
+		relationshipOption,
 	)
 
 	return (
 		<FocusZone>
 			<DialogConfirm
-				onConfirm={() => onUpdateFlippedConstraint(relationshipOption)}
+				onConfirm={onConfirmFlip}
 				toggle={toggleDialogConfirm}
 				show={showDialogConfirm}
 				title="Are you sure you want to proceed?"

--- a/javascript/app-discover/src/components/lists/EdgeList.types.ts
+++ b/javascript/app-discover/src/components/lists/EdgeList.types.ts
@@ -4,6 +4,7 @@
  */
 import type { SetterOrUpdater } from 'recoil'
 
+import type { CausalDiscoveryConstraints } from '../../domain/CausalDiscovery/CausalDiscoveryConstraints.js'
 import type { CausalVariable } from '../../domain/CausalVariable.js'
 import type { Relationship } from '../../domain/Relationship.jsx'
 import type { Selectable } from '../../domain/Selection.js'
@@ -12,4 +13,6 @@ export interface EdgeListProps {
 	relationships: Relationship[]
 	variable: CausalVariable
 	onSelect: SetterOrUpdater<Selectable>
+	constraints: CausalDiscoveryConstraints
+	onUpdateConstraints: SetterOrUpdater<CausalDiscoveryConstraints>
 }

--- a/javascript/app-discover/src/components/lists/EdgeList.types.ts
+++ b/javascript/app-discover/src/components/lists/EdgeList.types.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import type { SetterOrUpdater } from 'recoil'
+
+import type { CausalVariable } from '../../domain/CausalVariable.js'
+import type { Relationship } from '../../domain/Relationship.jsx'
+import type { Selectable } from '../../domain/Selection.js'
+
+export interface EdgeListProps {
+	relationships: Relationship[]
+	variable: CausalVariable
+	onSelect: SetterOrUpdater<Selectable>
+}

--- a/javascript/app-discover/src/components/lists/EdgeList.utils.ts
+++ b/javascript/app-discover/src/components/lists/EdgeList.utils.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import type { CausalDiscoveryConstraints } from '../../domain/CausalDiscovery/CausalDiscoveryConstraints.js'
+import type { Relationship } from '../../domain/Relationship.js'
+import {
+	hasSameReason,
+	hasSameSourceAndTarget,
+	invertRelationship,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
+
+export function removeEdge(
+	constraints: CausalDiscoveryConstraints,
+	onUpdateConstraints: (newConstraints: CausalDiscoveryConstraints) => void,
+	relationship: Relationship,
+) {
+	const newConstraints = {
+		...constraints,
+		manualRelationships: [
+			...constraints.manualRelationships,
+			{
+				...relationship,
+				reason: ManualRelationshipReason.Removed,
+			},
+		],
+	}
+	onUpdateConstraints(newConstraints)
+}
+export function pinEdge(
+	constraints: CausalDiscoveryConstraints,
+	onUpdateConstraints: (newConstraints: CausalDiscoveryConstraints) => void,
+	relationship: Relationship,
+) {
+	const newConstraints = {
+		...constraints,
+		manualRelationships: [
+			...constraints.manualRelationships.filter(
+				x => x.key !== relationship.key,
+			),
+			{
+				...relationship,
+				reason: ManualRelationshipReason.Pinned,
+			},
+		],
+	}
+	onUpdateConstraints(newConstraints)
+}
+
+export function flipEdge(
+	constraints: CausalDiscoveryConstraints,
+	onUpdateConstraints: (newConstraints: CausalDiscoveryConstraints) => void,
+	closeDialogConfirm: () => void,
+	relationship?: Relationship,
+) {
+	if (!relationship) return
+	const columns = [
+		relationship.source.columnName,
+		relationship.target.columnName,
+	]
+	const reverse = invertRelationship(relationship)
+	const existingRelationships = [...constraints.manualRelationships]
+	const isFlipped = constraints.manualRelationships.find(
+		r =>
+			hasSameSourceAndTarget(r, relationship) &&
+			hasSameReason(ManualRelationshipReason.Flipped, r),
+	)
+	const filtered = existingRelationships.filter(
+		r =>
+			!(
+				hasSameSourceAndTarget(r, relationship) &&
+				hasSameReason(ManualRelationshipReason.Flipped, r)
+			),
+	)
+	const newConstraints = {
+		causes: constraints.causes.filter(r => !columns.includes(r.columnName)),
+		effects: constraints.effects.filter(r => !columns.includes(r.columnName)),
+		manualRelationships: isFlipped
+			? filtered
+			: [
+					...filtered,
+					{
+						...reverse,
+						reason: ManualRelationshipReason.Flipped,
+					},
+			  ],
+	} as CausalDiscoveryConstraints
+
+	onUpdateConstraints(newConstraints)
+	closeDialogConfirm()
+}
+
+export function groupByEffectType(
+	relationships: Relationship[],
+	variableName: string,
+): { [index: string]: Relationship[] } {
+	return relationships.reduce(
+		(acc: { [index: string]: Relationship[] }, obj: Relationship) => {
+			let key = 'Is affected by'
+			switch (true) {
+				case obj.weight === undefined:
+					if (obj.source.columnName === variableName) {
+						key = 'Affects'
+					}
+					break
+				case (obj.weight || 0) > 0:
+					if (obj.source.columnName === variableName) {
+						key = 'Increases'
+						break
+					}
+					key = 'Is increased by'
+					break
+
+				case (obj.weight || 0) < 0:
+					if (obj.source.columnName === variableName) {
+						key = 'Decreases'
+						break
+					}
+					key = 'Is decreased by'
+			}
+
+			if (!acc[key]) {
+				acc[key] = []
+			}
+
+			acc[key].push(obj)
+			return acc
+		},
+		{},
+	)
+}

--- a/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
+++ b/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
@@ -18,6 +18,7 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 		const [constraints, setConstraints] = useRecoilState(
 			CausalGraphConstraintsState,
 		)
+		console.log('constraints', constraints)
 		const resetConstraints = useResetRecoilState(CausalGraphConstraintsState)
 
 		const removeFromRelationshipConstraints = (

--- a/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
+++ b/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
@@ -8,7 +8,10 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil'
 
 import type { VariableReference } from '../../domain/CausalVariable.js'
 import type { RelationshipReference } from '../../domain/Relationship.js'
-import { ManualRelationshipReason } from '../../domain/Relationship.js'
+import {
+	hasSameReason,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
 import { CausalGraphConstraintsState, TableState } from '../../state/index.js'
 import { IconButtonDark } from '../../styles/styles.js'
 import { Divider } from '../controls/Divider.js'
@@ -49,16 +52,23 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 						<TooltipHost content={constraint.reason}>
 							<Icon
 								iconName={
-									constraint.reason === ManualRelationshipReason.Flipped
+									hasSameReason(ManualRelationshipReason.Flipped, constraint)
 										? icons.switch.iconName
+										: hasSameReason(
+												ManualRelationshipReason.Removed,
+												constraint,
+										  )
+										? icons.delete.iconName
 										: icons.pinned.iconName
 								}
 							></Icon>
 						</TooltipHost>
-						<IconButtonDark
-							iconProps={icons.delete}
-							onClick={() => removeFromRelationshipConstraints(constraint)}
-						/>
+						<TooltipHost content="Remove constraint">
+							<IconButtonDark
+								iconProps={icons.remove}
+								onClick={() => removeFromRelationshipConstraints(constraint)}
+							/>
+						</TooltipHost>
 					</Stack.Item>
 				</Stack>
 			),
@@ -141,6 +151,7 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 
 const icons = {
 	delete: { iconName: 'Delete' },
+	remove: { iconName: 'StatusCircleErrorX' },
 	switch: { iconName: 'Switch' },
 	pinned: { iconName: 'PinSolid12' },
 }

--- a/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
+++ b/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
@@ -2,12 +2,13 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { DefaultButton, Stack } from '@fluentui/react'
+import { DefaultButton, Icon, Stack, TooltipHost } from '@fluentui/react'
 import { memo } from 'react'
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil'
 
 import type { VariableReference } from '../../domain/CausalVariable.js'
 import type { RelationshipReference } from '../../domain/Relationship.js'
+import { ManualRelationshipReason } from '../../domain/Relationship.js'
 import { CausalGraphConstraintsState, TableState } from '../../state/index.js'
 import { IconButtonDark } from '../../styles/styles.js'
 import { Divider } from '../controls/Divider.js'
@@ -45,7 +46,15 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 						grow
 					>{`${constraint.source.columnName}-${constraint.target.columnName}`}</Stack.Item>
 					<Stack.Item>
-						{constraint.reason}
+						<TooltipHost content={constraint.reason}>
+							<Icon
+								iconName={
+									constraint.reason === ManualRelationshipReason.Flipped
+										? icons.switch.iconName
+										: icons.pinned.iconName
+								}
+							></Icon>
+						</TooltipHost>
 						<IconButtonDark
 							iconProps={icons.delete}
 							onClick={() => removeFromRelationshipConstraints(constraint)}
@@ -117,7 +126,9 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 				{causeConstraints}
 				{effectConstraints.length > 0 && <Divider>Effect Constraints</Divider>}
 				{effectConstraints}
-				{relationshipConstraints.length > 0 && <Divider>Edges</Divider>}
+				{relationshipConstraints.length > 0 && (
+					<Divider>Edge Constraints</Divider>
+				)}
 				{relationshipConstraints}
 				<Divider></Divider>
 				<DefaultButton onClick={resetConstraints}>
@@ -130,4 +141,6 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 
 const icons = {
 	delete: { iconName: 'Delete' },
+	switch: { iconName: 'Switch' },
+	pinned: { iconName: 'PinSolid12' },
 }

--- a/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
+++ b/javascript/app-discover/src/components/panels/ConstraintsPanel.tsx
@@ -8,14 +8,11 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil'
 
 import type { VariableReference } from '../../domain/CausalVariable.js'
 import type { RelationshipReference } from '../../domain/Relationship.js'
-import {
-	hasSameReason,
-	ManualRelationshipReason,
-} from '../../domain/Relationship.js'
 import { CausalGraphConstraintsState, TableState } from '../../state/index.js'
 import { IconButtonDark } from '../../styles/styles.js'
 import { Divider } from '../controls/Divider.js'
 import type { ConstraintsPanelProps } from './ConstraintsPanel.types.js'
+import { getConstraintIconName } from './ConstraintsPanel.utils.js'
 
 export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 	function ConstraintsPanel({ children }) {
@@ -50,18 +47,7 @@ export const ConstraintsPanel: React.FC<ConstraintsPanelProps> = memo(
 					>{`${constraint.source.columnName}-${constraint.target.columnName}`}</Stack.Item>
 					<Stack.Item>
 						<TooltipHost content={constraint.reason}>
-							<Icon
-								iconName={
-									hasSameReason(ManualRelationshipReason.Flipped, constraint)
-										? icons.switch.iconName
-										: hasSameReason(
-												ManualRelationshipReason.Removed,
-												constraint,
-										  )
-										? icons.delete.iconName
-										: icons.pinned.iconName
-								}
-							></Icon>
+							<Icon iconName={getConstraintIconName(constraint)}></Icon>
 						</TooltipHost>
 						<TooltipHost content="Remove constraint">
 							<IconButtonDark

--- a/javascript/app-discover/src/components/panels/ConstraintsPanel.utils.ts
+++ b/javascript/app-discover/src/components/panels/ConstraintsPanel.utils.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import type { Relationship } from '../../domain/Relationship.js'
+import {
+	hasSameReason,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
+import { icons } from '../lists/EdgeItem.styles.js'
+
+export function getConstraintIconName(constraint: Relationship) {
+	return hasSameReason(ManualRelationshipReason.Flipped, constraint)
+		? icons.switch.iconName
+		: hasSameReason(ManualRelationshipReason.Removed, constraint)
+		? icons.delete.iconName
+		: icons.pinned.iconName
+}

--- a/javascript/app-discover/src/components/panels/RelationshipPropertiesPanel.tsx
+++ b/javascript/app-discover/src/components/panels/RelationshipPropertiesPanel.tsx
@@ -42,10 +42,7 @@ export const RelationshipPropertiesPanel: React.FC<RelationshipPropertiesPanelPr
 		const addToConstraints = () => {
 			const newConstraints = {
 				...constraints,
-				forbiddenRelationships: [
-					...constraints.forbiddenRelationships,
-					relationship,
-				],
+				manualRelationships: [...constraints.manualRelationships, relationship],
 			}
 			setConstraints(newConstraints)
 		}

--- a/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
+++ b/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+import { DialogConfirm } from '@essex/components'
 import type {
 	IChoiceGroupOption,
 	IChoiceGroupOptionProps,
@@ -14,7 +15,8 @@ import {
 	Text,
 	TooltipHost,
 } from '@fluentui/react'
-import { memo } from 'react'
+import { useBoolean } from '@fluentui/react-hooks'
+import { memo, useCallback, useState } from 'react'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
 import {
@@ -24,6 +26,7 @@ import {
 } from '../../domain/CausalDiscovery/CausalDiscoveryConstraints.js'
 import { isAddable } from '../../domain/CausalVariable.js'
 import * as Graph from '../../domain/Graph.js'
+import { involvesVariable } from '../../domain/Relationship.js'
 import { VariableNature } from '../../domain/VariableNature.js'
 import {
 	CausalGraphConstraintsState,
@@ -48,6 +51,11 @@ import type { VariablePropertiesPanelProps } from './VariablePropertiesPanel.typ
 export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 	memo(function VariablePropertiesPanel({ variable }) {
 		const dataset = useRecoilValue(DatasetState)
+		const [
+			showDialogConfirm,
+			{ toggle: toggleDialogConfirm, setFalse: closeDialogConfirm },
+		] = useBoolean(false)
+		const [constraintOption, setConstraintOption] = useState('')
 		const causalGraph = useCausalGraph()
 		const weightThreshold = useRecoilValue(WeightThresholdState)
 		const confidenceThreshold = useRecoilValue(ConfidenceThresholdState)
@@ -68,18 +76,50 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 			CausalGraphConstraintsState,
 		)
 
-		const onChange = (
-			e?: React.FormEvent<HTMLElement | HTMLInputElement>,
-			option?: IChoiceGroupOption,
-		): void => {
-			setConstraints(
-				updateConstraints(
-					constraints,
-					variable,
-					Constraints[option?.key as keyof typeof Constraints],
-				),
-			)
-		}
+		const onUpdateConstraints = useCallback(
+			(constraintKey?: string) => {
+				setConstraints(
+					updateConstraints(
+						constraints,
+						variable,
+						Constraints[constraintKey as keyof typeof Constraints],
+					),
+				)
+				setConstraintOption('')
+				closeDialogConfirm()
+			},
+			[
+				setConstraintOption,
+				variable,
+				constraintOption,
+				setConstraints,
+				closeDialogConfirm,
+			],
+		)
+
+		const onChange = useCallback(
+			(
+				e?: React.FormEvent<HTMLElement | HTMLInputElement>,
+				option?: IChoiceGroupOption,
+			) => {
+				if (
+					constraints.manualRelationships?.find(r =>
+						involvesVariable(r, variable),
+					)
+				) {
+					setConstraintOption(option?.key as string)
+					return toggleDialogConfirm()
+				}
+				onUpdateConstraints(option?.key)
+			},
+			[
+				onUpdateConstraints,
+				toggleDialogConfirm,
+				constraints,
+				setConstraintOption,
+				variable,
+			],
+		)
 
 		// TODO: DRY this out. It's also in CausalNode
 		const addToModel = () => {
@@ -147,11 +187,16 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 				),
 			} as IChoiceGroupOption,
 		]
-		console.log('relationships', relationships)
-		console.log('constraints', constraints)
 
 		return (
 			<>
+				<DialogConfirm
+					onConfirm={() => onUpdateConstraints(constraintOption)}
+					toggle={toggleDialogConfirm}
+					show={showDialogConfirm}
+					title="Are you sure you want to proceed?"
+					subText="Setting this constraint will remove any manual edges you pinned or flipped for this variable"
+				></DialogConfirm>
 				<Text variant={'large'} block>
 					{variable.name}
 				</Text>

--- a/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
+++ b/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
@@ -89,9 +89,9 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 				closeDialogConfirm()
 			},
 			[
+				constraints,
 				setConstraintOption,
 				variable,
-				constraintOption,
 				setConstraints,
 				closeDialogConfirm,
 			],

--- a/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
+++ b/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
@@ -211,15 +211,6 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 							)
 						))}
 				</Stack>
-				<Divider>Edges</Divider>
-				{relationships && (
-					<EdgeList
-						onSelect={setSelectedObject}
-						variable={variable}
-						relationships={relationships}
-					/>
-				)}
-
 				{isInModel && (
 					<>
 						<Divider>Constraint</Divider>
@@ -230,6 +221,17 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 						/>
 					</>
 				)}
+				<Divider>Edges</Divider>
+				{relationships && (
+					<EdgeList
+						onSelect={setSelectedObject}
+						variable={variable}
+						relationships={relationships}
+						constraints={constraints}
+						onUpdateConstraints={setConstraints}
+					/>
+				)}
+
 				<Divider>Correlations</Divider>
 				<VariableCorrelationsList variable={variable} />
 			</>

--- a/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
+++ b/javascript/app-discover/src/components/panels/VariablePropertiesPanel.tsx
@@ -27,14 +27,18 @@ import * as Graph from '../../domain/Graph.js'
 import { VariableNature } from '../../domain/VariableNature.js'
 import {
 	CausalGraphConstraintsState,
+	ConfidenceThresholdState,
 	DatasetState,
 	InModelCausalVariablesState,
+	SelectedObjectState,
 	useCausalGraph,
+	WeightThresholdState,
 } from '../../state/index.js'
 import { Chart } from '../charts/Chart.js'
 import { Divider } from '../controls/Divider.js'
 import { VariableNaturePicker } from '../controls/VariableNaturePicker.js'
 import { VariableCorrelationsList } from '../lists/CorrelationList.js'
+import { EdgeList } from '../lists/EdgeList.js'
 import {
 	add_remove_button_styles,
 	panel_stack_tokens,
@@ -45,11 +49,21 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 	memo(function VariablePropertiesPanel({ variable }) {
 		const dataset = useRecoilValue(DatasetState)
 		const causalGraph = useCausalGraph()
+		const weightThreshold = useRecoilValue(WeightThresholdState)
+		const confidenceThreshold = useRecoilValue(ConfidenceThresholdState)
+		const [, setSelectedObject] = useRecoilState(SelectedObjectState)
+
 		const [inModelVariables, setInModelVariables] = useRecoilState(
 			InModelCausalVariablesState,
 		)
 
 		const isInModel = Graph.includesVariable(causalGraph, variable)
+		const relationships = Graph.validRelationshipsForColumnName(
+			causalGraph,
+			variable,
+			weightThreshold,
+			confidenceThreshold,
+		)
 		const [constraints, setConstraints] = useRecoilState(
 			CausalGraphConstraintsState,
 		)
@@ -133,6 +147,8 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 				),
 			} as IChoiceGroupOption,
 		]
+		console.log('relationships', relationships)
+		console.log('constraints', constraints)
 
 		return (
 			<>
@@ -195,6 +211,15 @@ export const VariablePropertiesPanel: React.FC<VariablePropertiesPanelProps> =
 							)
 						))}
 				</Stack>
+				<Divider>Edges</Divider>
+				{relationships && (
+					<EdgeList
+						onSelect={setSelectedObject}
+						variable={variable}
+						relationships={relationships}
+					/>
+				)}
+
 				{isInModel && (
 					<>
 						<Divider>Constraint</Divider>

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
@@ -156,7 +156,7 @@ function createConstraintsJson(
 		effects: constraints.effects
 			.filter(variable => arrayIncludesVariable(variables, variable))
 			.map(variable => variable.columnName),
-		forbiddenRelationships: constraints.forbiddenRelationships
+		forbiddenRelationships: constraints.manualRelationships
 			.filter(
 				relationship =>
 					arrayIncludesVariable(variables, relationship.source) &&

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryConstraints.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryConstraints.tsx
@@ -4,6 +4,7 @@
  */
 import type { VariableReference } from '../CausalVariable.js'
 import type { Relationship } from '../Relationship.js'
+import { involvesVariable } from '../Relationship.js'
 
 export interface CausalDiscoveryConstraints {
 	causes: VariableReference[]
@@ -46,6 +47,7 @@ export const updateConstraints = (
 	constraintType: Constraints,
 ) => {
 	let { causes, effects } = constraints
+	const { manualRelationships } = constraints
 	const currentConstraintType = getConstraintType(constraints, variable)
 	if (currentConstraintType === Constraints.Cause) {
 		causes = removeConstraint(causes, variable)
@@ -58,9 +60,15 @@ export const updateConstraints = (
 	} else if (constraintType === Constraints.Effect) {
 		effects = addConstraint(effects, variable)
 	}
+	const filteredConstraints = {
+		...constraints,
+		manualRelationships: manualRelationships.filter(
+			r => !involvesVariable(r, variable),
+		),
+	}
 
 	return {
-		...constraints,
+		...filteredConstraints,
 		causes,
 		effects,
 	}

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryConstraints.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryConstraints.tsx
@@ -3,12 +3,12 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { VariableReference } from '../CausalVariable.js'
-import type { RelationshipReference } from '../Relationship.js'
+import type { Relationship } from '../Relationship.js'
 
 export interface CausalDiscoveryConstraints {
 	causes: VariableReference[]
 	effects: VariableReference[]
-	forbiddenRelationships: RelationshipReference[]
+	manualRelationships: Relationship[]
 }
 
 export enum Constraints {

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryResult.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryResult.tsx
@@ -19,7 +19,7 @@ export const EMPTY_CAUSAL_DISCOVERY_RESULT = {
 		constraints: {
 			causes: [],
 			effects: [],
-			forbiddenRelationships: [],
+			manualRelationships: [],
 		},
 		algorithm: CausalDiscoveryAlgorithm.None,
 	},

--- a/javascript/app-discover/src/domain/Graph.tsx
+++ b/javascript/app-discover/src/domain/Graph.tsx
@@ -6,8 +6,11 @@ import type { CausalDiscoveryAlgorithm } from './CausalDiscovery/CausalDiscovery
 import type { CausalDiscoveryConstraints } from './CausalDiscovery/CausalDiscoveryConstraints.js'
 import type { CausalVariable, VariableReference } from './CausalVariable.js'
 import { arrayIncludesVariable, isSame } from './CausalVariable.js'
-import type { Relationship } from './Relationship.js'
-import { hasSameSourceAndTargetColumns } from './Relationship.js'
+import {
+	type Relationship,
+	hasSameSourceAndTargetColumns,
+	involvesVariable,
+} from './Relationship.js'
 
 export interface CausalGraph {
 	variables: CausalVariable[]
@@ -113,6 +116,26 @@ export function relationshipsForColumnNames(
 	return graph.relationships.find(relationship =>
 		hasSameSourceAndTargetColumns(relationship, source, target),
 	)
+}
+
+export function validRelationshipsForColumnName(
+	graph: CausalGraph,
+	variable: VariableReference,
+	weightThreshold: number,
+	confidenceThreshold: number,
+): Relationship[] | undefined {
+	return graph.relationships
+		?.flatMap(relationship =>
+			involvesVariable(relationship, variable) &&
+			isRelationshipAboveThresholds(
+				relationship,
+				weightThreshold,
+				confidenceThreshold,
+			)
+				? relationship
+				: [],
+		)
+		?.sort((a, b) => Math.abs(b?.weight || 0) - Math.abs(a?.weight || 0))
 }
 
 export function includesVariable(

--- a/javascript/app-discover/src/domain/Relationship.tsx
+++ b/javascript/app-discover/src/domain/Relationship.tsx
@@ -153,3 +153,10 @@ export function arrayIncludesRelationship(
 		hasSameSourceAndTarget(relationship, otherRelationship),
 	)
 }
+
+export function hasSameReason(
+	reason: ManualRelationshipReason,
+	relationship?: Relationship,
+) {
+	return relationship?.reason === reason
+}

--- a/javascript/app-discover/src/domain/Relationship.tsx
+++ b/javascript/app-discover/src/domain/Relationship.tsx
@@ -160,3 +160,14 @@ export function hasSameReason(
 ) {
 	return relationship?.reason === reason
 }
+
+export function isEquivalentRelationship(
+	relationship: Relationship,
+	asRelationship: Relationship,
+) {
+	return (
+		hasSameSourceAndTarget(relationship, asRelationship) ||
+		(hasSameReason(ManualRelationshipReason.Flipped, asRelationship) &&
+			hasInvertedSourceAndTarget(relationship, asRelationship))
+	)
+}

--- a/javascript/app-discover/src/domain/Relationship.tsx
+++ b/javascript/app-discover/src/domain/Relationship.tsx
@@ -7,9 +7,17 @@ import type ColumnTable from 'arquero/dist/types/table/column-table'
 import type { CausalVariable, VariableReference } from './CausalVariable.js'
 import { applyMappingFromVariableToTable, isSame } from './CausalVariable.js'
 
+export enum ManualRelationshipReason {
+	Removed = 'Removed',
+	Pinned = 'Pinned',
+	Flipped = 'Flipped',
+	Unknown = 'Unknown',
+}
+
 export interface RelationshipReference {
 	source: VariableReference
 	target: VariableReference
+	reason?: ManualRelationshipReason
 }
 
 export type Relationship = RelationshipReference & {

--- a/javascript/app-discover/src/domain/Relationship.tsx
+++ b/javascript/app-discover/src/domain/Relationship.tsx
@@ -11,7 +11,6 @@ export enum ManualRelationshipReason {
 	Removed = 'Removed',
 	Pinned = 'Pinned',
 	Flipped = 'Flipped',
-	Unknown = 'Unknown',
 }
 
 export interface RelationshipReference {

--- a/javascript/app-discover/src/state/atoms/causal_graph.ts
+++ b/javascript/app-discover/src/state/atoms/causal_graph.ts
@@ -25,7 +25,7 @@ export const CausalGraphConstraintsState = atom<CausalDiscoveryConstraints>({
 	default: {
 		causes: [],
 		effects: [],
-		forbiddenRelationships: [],
+		manualRelationships: [],
 	},
 	// eslint-disable-next-line camelcase
 	effects_UNSTABLE: [persistAtomEffect, persistAtom],

--- a/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
+++ b/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
@@ -6,7 +6,14 @@ import { useEffect, useMemo } from 'react'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { discover as runCausalDiscovery } from '../../domain/CausalDiscovery/CausalDiscovery.js'
-import type { RelationshipReference } from '../../domain/Relationship.js'
+import type {
+	Relationship,
+	RelationshipReference,
+} from '../../domain/Relationship.js'
+import {
+	invertRelationship,
+	ManualRelationshipReason,
+} from '../../domain/Relationship.js'
 import {
 	CausalDiscoveryResultsState,
 	CausalGraphConstraintsState,
@@ -62,10 +69,21 @@ export function useCausalDiscoveryRunner() {
 	const causalDiscoveryConstraints = useMemo(
 		() => ({
 			...userConstraints,
-			forbiddenRelationships: [
-				...userConstraints.forbiddenRelationships,
+			manualRelationships: [
+				...userConstraints.manualRelationships.map(x => {
+					if (
+						x.reason &&
+						[
+							ManualRelationshipReason.Flipped,
+							ManualRelationshipReason.Pinned,
+						].includes(x.reason)
+					) {
+						return invertRelationship(x)
+					}
+					return x
+				}),
 				...derivedConstraints,
-			],
+			] as Relationship[],
 		}),
 		[userConstraints, derivedConstraints],
 	)

--- a/javascript/app-discover/src/styles/styles.tsx
+++ b/javascript/app-discover/src/styles/styles.tsx
@@ -3,6 +3,10 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 
+import type { ITheme } from '@fluentui/react'
+import { IconButton } from '@fluentui/react'
+import styled from 'styled-components'
+
 export const containerPadding = 5
 export const padding = {
 	paddingLeft: containerPadding,
@@ -23,3 +27,7 @@ export const colorNegativeFaded = '#aa666633'
 export const addedStyle = { filter: 'drop-shadow(-1px 1px 2px #FFAA44)' }
 export const colorCorrelation = 'rgb(120, 120, 120)'
 export const colorCorrelationFaded = 'rgb(120, 120, 120, 0.5)'
+
+export const IconButtonDark = styled(IconButton)`
+	color: ${({ theme }: { theme: ITheme }) => theme.palette.black};
+`

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -612,7 +612,7 @@
                     "constraints": {
                         "causes": [],
                         "effects": [],
-                        "forbiddenRelationships": []
+                        "manualRelationships": []
                     },
                     "results": {
                         "graph": {
@@ -621,7 +621,7 @@
                             "constraints": {
                                 "causes": [],
                                 "effects": [],
-                                "forbiddenRelationships": []
+                                "manualRelationships": []
                             },
                             "algorithm": "NOTEARS"
                         },


### PR DESCRIPTION
- forbiddenRelationships in the front-end logic is called manualRelationships. But to send to the API we still only have the forbidden props, because it's not possible to pass the edges we want for now, only the edges we don't want.
- update buttons in layout (panels, lists and graph) to look and feel like buttons
- fix variable or constraint bug when a column name was too big, and the button was overflowing on top of other info
- add edges list when a node is selected
- shows edge constraints with the reason in the general right properties panel
- edge (relationship) options:
  - pin: set this edge as relevant, sending the inverse of it as forbidden to the backend (toggle button, click to undo)
  - flip: reverses the edge and set is as flipped, sending the inverse of it (the first one clicked now) as forbidden to the backend (toggle button, click to undo)
  - delete: set this edge as removed, sending it as forbidden to the backend
  - clicking on an edge on the list will show the edge details (same as clicking on the edge on the graph)
- when an edge is pinned, it can't be flipped 
- when an edge is switched, it can't be pinned
- when a general constraint is changed for a node, it verifies first if there's any manual relations included for this node. If there is, shows a confirm modal because those manual relations will be removed.
- when a general constraint exists for a node and you flip or pin any edge, it shows a confirm modal because it will remove the general constraint