### PR TITLE
Updating discover backend to scale continuous column using std/mean

### DIFF
--- a/javascript/app-discover/src/components/CauseDis.tsx
+++ b/javascript/app-discover/src/components/CauseDis.tsx
@@ -4,14 +4,14 @@
  */
 import 'allotment/dist/style.css'
 
-import { Spinner } from '@fluentui/react'
+import { MessageBar, MessageBarType, Spinner } from '@fluentui/react'
 import { CommonLayout } from '@showwhy/app-common'
 import { Allotment } from 'allotment'
 import { memo, Suspense } from 'react'
 import { useMeasure } from 'react-use'
 import { useRecoilValue } from 'recoil'
 
-import { LoadingState } from '../state/index.js'
+import { ErrorMessageState, LoadingState } from '../state/index.js'
 import {
 	FillContainer,
 	FullScreenContainer,
@@ -27,7 +27,9 @@ import { PropertyPanels } from './panels/PropertyPanels.js'
 
 export const CauseDis = memo(function CauseDis() {
 	const loading = useRecoilValue(LoadingState)
+	const errorMessage = useRecoilValue(ErrorMessageState)
 	const [ref, { width, height }] = useMeasure<HTMLDivElement>()
+
 	return (
 		<CommonLayout
 			configRail={<AppLeftRail />}
@@ -38,6 +40,11 @@ export const CauseDis = memo(function CauseDis() {
 				</Suspense>
 			}
 		>
+			{errorMessage && (
+				<MessageBar messageBarType={MessageBarType.error}>
+					{errorMessage}
+				</MessageBar>
+			)}
 			{loading ? (
 				<Spinner label={loading} />
 			) : (

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
@@ -115,6 +115,10 @@ export function discover(
 			dataset: JSON.parse(jsonData),
 			constraints: constraintsJson,
 			training_options: trainingOptions,
+			causal_variables: variables.map(v => ({
+				name: v.name,
+				nature: v.nature,
+			})),
 		}),
 		progressCallback,
 	)

--- a/javascript/app-discover/src/state/atoms/ui.ts
+++ b/javascript/app-discover/src/state/atoms/ui.ts
@@ -8,6 +8,11 @@ import { GraphViewStates } from '../../components/graph/GraphViews.types.js'
 import { CausalDiscoveryAlgorithm } from '../../domain/CausalDiscovery/CausalDiscoveryAlgorithm.js'
 import type { Selectable } from '../../domain/Selection.js'
 
+export const ErrorMessageState = atom<string | undefined>({
+	key: 'ErrorMessageState',
+	default: undefined,
+})
+
 export const LoadingState = atom<string | undefined>({
 	key: 'LoadingState',
 	default: undefined,

--- a/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
+++ b/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
@@ -19,6 +19,7 @@ import {
 	CausalDiscoveryResultsState,
 	CausalGraphConstraintsState,
 	DEFAULT_DATASET_NAME,
+	ErrorMessageState,
 	LoadingState,
 	PauseAutoRunState,
 	SelectedCausalDiscoveryAlgorithmState,
@@ -48,6 +49,7 @@ export function useCausalDiscoveryRunner() {
 		CausalDiscoveryResultsState,
 	)
 	const setLoadingState = useSetRecoilState(LoadingState)
+	const setErrorMessage = useSetRecoilState(ErrorMessageState)
 	const [setLastDiscoveryResultPromise, cancelLastDiscoveryResultPromise] =
 		useLastDiscoveryResultPromise()
 
@@ -119,6 +121,8 @@ export function useCausalDiscoveryRunner() {
 
 		updateProgress(0, undefined)
 		const runDiscovery = async () => {
+			setErrorMessage(undefined)
+
 			// if the last task has not finished just yet, cancel it
 			await cancelLastDiscoveryResultPromise()
 
@@ -139,15 +143,16 @@ export function useCausalDiscoveryRunner() {
 				if (discoveryPromise.isFinished()) {
 					setCausalDiscoveryResultsState(results)
 					setLoadingState(undefined)
+					setErrorMessage(undefined)
 				}
 			} catch (err) {
 				if (err instanceof CanceledPromiseError) {
 					setLoadingState('Cancelling last run...')
+					setErrorMessage(undefined)
 				} else {
-					// TODO: handle error message in the UI
-					console.error(err)
 					resetCausalDiscoveryResultsState()
 					setLoadingState(undefined)
+					setErrorMessage((err as Error).message)
 				}
 			}
 		}
@@ -168,5 +173,6 @@ export function useCausalDiscoveryRunner() {
 		updateProgress,
 		cancelLastDiscoveryResultPromise,
 		setLastDiscoveryResultPromise,
+		setErrorMessage,
 	])
 }

--- a/python/backend/backend/discover/algorithms/deci.py
+++ b/python/backend/backend/discover/algorithms/deci.py
@@ -10,25 +10,22 @@ import numpy as np
 import pandas as pd
 import torch
 from causica.datasets.dataset import Dataset
+from causica.datasets.variables import Variables
 from causica.models.deci.deci_gaussian import DECIGaussian
 from causica.models.deci.generation_functions import ContractiveInvertibleGNN
 from causica.utils.torch_utils import get_torch_device
 from celery import uuid
 from networkx.readwrite import json_graph
 from pydantic import BaseModel
-from sklearn.preprocessing import MaxAbsScaler
 
 from backend.discover.algorithms.commons.base_runner import (
     CausalDiscoveryRunner,
     CausalGraph,
     ProgressCallback,
 )
-from backend.discover.algorithms.commons.pandas_dataset_loader import (
-    PandasDatasetLoader,
-)
 from backend.discover.model.causal_discovery import (
     CausalDiscoveryPayload,
-    CausalVariableNature,
+    map_to_causica_var_type,
 )
 
 torch.set_default_dtype(torch.float32)
@@ -89,33 +86,30 @@ class DeciRunner(CausalDiscoveryRunner):
         # make sure every run has its own folder
         self._deci_save_dir = f"CauseDisDECIDir/{uuid()}"
 
-    def _scale_non_binary_and_non_continuous(self):
-        columns_to_scale = []
-
-        for column in self._prepared_data.columns:
-            nature = self._nature_by_variable[column]
-            if (
-                nature
-                and nature != CausalVariableNature.Binary
-                and nature != CausalVariableNature.Continuous
-            ):
-                columns_to_scale.append(column)
-
-        if columns_to_scale:
-            self._prepared_data[columns_to_scale] = MaxAbsScaler().fit_transform(
-                self._prepared_data[columns_to_scale]
-            )
-
     def _build_causica_dataset(self) -> Dataset:
-        # TODO: normalizing non binary and non continuous
+        numpy_data = self._prepared_data.to_numpy()
+        data_mask = np.ones(numpy_data.shape)
+
+        # TODO: mapping non binary and non continuous to continuous
         # columns for now, until we work around representing
         # categorical variables with ONNX
-        self._scale_non_binary_and_non_continuous()
-        causica_dataset = PandasDatasetLoader("").split_data_and_load_dataset(
-            self._prepared_data, 0.5, 0, 0
+        variables = Variables.create_from_data_and_dict(
+            numpy_data,
+            data_mask,
+            {
+                "variables": [
+                    {
+                        "name": name,
+                        "type": map_to_causica_var_type(self._nature_by_variable[name]),
+                        "lower": self._prepared_data[name].min(),
+                        "upper": self._prepared_data[name].max(),
+                    }
+                    for name in self._prepared_data.columns
+                ]
+            },
         )
 
-        return causica_dataset
+        return Dataset(train_data=numpy_data, train_mask=data_mask, variables=variables)
 
     def _build_model(self, causica_dataset: Dataset) -> DECIGaussian:
         deci_model = DECIGaussian(

--- a/python/backend/backend/discover/api/router.py
+++ b/python/backend/backend/discover/api/router.py
@@ -33,6 +33,11 @@ def get_discover_results(task_id: str):
     async_task = causal_discovery_task.AsyncResult(task_id)
     if async_task.status == states.SUCCESS:
         return {"status": async_task.status, "result": async_task.get()}
+    elif async_task.status == states.FAILURE:
+        try:
+            return {"status": async_task.status, "result": async_task.get()}
+        except Exception as err:
+            return {"status": async_task.status, "result": str(err)}
     else:
         return {"status": async_task.status, "progress": get_progress(async_task)}
 

--- a/python/backend/backend/discover/api/router.py
+++ b/python/backend/backend/discover/api/router.py
@@ -36,8 +36,11 @@ def get_discover_results(task_id: str):
     elif async_task.status == states.FAILURE:
         try:
             return {"status": async_task.status, "result": async_task.get()}
-        except Exception as err:
-            return {"status": async_task.status, "result": str(err)}
+        except Exception:
+            return {
+                "status": async_task.status,
+                "result": "error processing task, maybe the combination of parameters/variables is invalid?",
+            }
     else:
         return {"status": async_task.status, "progress": get_progress(async_task)}
 

--- a/python/backend/backend/discover/model/causal_discovery.py
+++ b/python/backend/backend/discover/model/causal_discovery.py
@@ -35,3 +35,17 @@ class CausalDiscoveryPayload(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+
+_causal_var_nature_to_causica_var_type = {
+    "Discrete": "continuous",  # TODO: make categorical (related to ONNX)
+    "Continuous": "continuous",
+    "Categorical Ordinal": "continuous",  # TODO: make categorical (related to ONNX)
+    "Categorical Nominal": "continuous",  # TODO: make categorical (related to ONNX)
+    "Binary": "binary",
+    "Excluded": "continuous",
+}
+
+
+def map_to_causica_var_type(nature: CausalVariableNature):
+    return _causal_var_nature_to_causica_var_type.get(nature, "continuous")

--- a/python/backend/backend/discover/model/causal_discovery.py
+++ b/python/backend/backend/discover/model/causal_discovery.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Tuple
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -9,6 +10,20 @@ class Constraints(BaseModel):
     forbiddenRelationships: List[Tuple[str, str]]
 
 
+class CausalVariableNature(str, Enum):
+    Discrete = "Discrete"
+    Continuous = "Continuous"
+    CategoricalOrdinal = "Categorical Ordinal"
+    CategoricalNominal = "Categorical Nominal"
+    Binary = "Binary"
+    Excluded = "Excluded"
+
+
+class CausalVariable(BaseModel):
+    name: str
+    nature: Optional[CausalVariableNature] = None
+
+
 class Dataset(BaseModel):
     data: Dict[str, List[Any]]
 
@@ -16,6 +31,7 @@ class Dataset(BaseModel):
 class CausalDiscoveryPayload(BaseModel):
     dataset: Dataset
     constraints: Constraints
+    causal_variables: List[CausalVariable]
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
- Updating discover backend to scale continuous column using std/mean
- DECI: For non-binary, non-continuous columns are mapped to continuous columns (TODO: need to validate ONNX approach for categorical columns)
- Propagating discovery backend error to the frontend