### PR TITLE
3d width, deci sliders and vega chart ordering update

### DIFF
--- a/javascript/app-discover/src/components/graph/CausalGraphNode.hooks.ts
+++ b/javascript/app-discover/src/components/graph/CausalGraphNode.hooks.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { useCausalInferenceModel } from '../../state/index.js'
 
 export function useIsCausalInferenceSupported(): boolean {
-	const state = useCausalInferenceModel()
-	return state != null
+	// const state = useCausalInferenceModel()
+	// return state != null
+	return false // disabled until we have a more efficient way to compute inference
 }

--- a/javascript/app-discover/src/components/graph/NetworkGraphExplorer.tsx
+++ b/javascript/app-discover/src/components/graph/NetworkGraphExplorer.tsx
@@ -120,11 +120,11 @@ export const NetworkGraphExplorer: React.FC<NetworkGraphProps> = memo(
 						width={width}
 						height={height}
 						backgroundColor={'#FFF'}
-						linkWidth={link => 5 * Math.abs((link as NetworkGraphLink).value)}
+						linkWidth={link => 2 * Math.abs((link as NetworkGraphLink).value)}
 						linkColor={link =>
 							`rgba(0,0,0,${Math.abs((link as NetworkGraphLink).value)})`
 						}
-						linkOpacity={1}
+						linkOpacity={0.8}
 						nodeThreeObject={(node: NetworkGraphNode) => {
 							const sprite = new SpriteText(node.name)
 							const isInModel = inModelColumnNames.includes(node.id)
@@ -144,7 +144,7 @@ export const NetworkGraphExplorer: React.FC<NetworkGraphProps> = memo(
 						width={width}
 						height={height}
 						d3VelocityDecay={0.5}
-						linkWidth={link => 5 * Math.abs((link as NetworkGraphLink).value)}
+						linkWidth={link => 2 * Math.abs((link as NetworkGraphLink).value)}
 						linkColor={link =>
 							`rgba(0,0,0,${Math.abs((link as NetworkGraphLink).value)})`
 						}

--- a/javascript/app-model-exposure/src/components/VegaSpecificationCurve.tsx
+++ b/javascript/app-model-exposure/src/components/VegaSpecificationCurve.tsx
@@ -66,24 +66,17 @@ export const VegaSpecificationCurve: React.FC<{
 		[selected, onSpecificationSelect],
 	)
 
-	const updateIds = useCallback(
-		(newList: Specification[]) => {
-			const totalEstimatesReturned = latestList.length
-			if (selected && totalSpecs !== totalEstimatesReturned) {
-				const item = latestList.find(x => x.id === selected)
-				const newItem = newList.find(x => x.taskId === item?.taskId)
-				if (newItem?.id !== item?.id) {
-					onChangeSelectedItem(newItem?.id)
-				}
-			}
-			setLatestList(newList)
-		},
-		[latestList, selected, setLatestList, onChangeSelectedItem, totalSpecs],
-	)
-
 	useEffect(() => {
-		updateIds(data)
-	}, [data, updateIds])
+		const totalEstimatesReturned = latestList.length
+		if (selected && totalSpecs !== totalEstimatesReturned) {
+			const item = latestList.find(i => i.id === selected)
+			const newItem = data.find(d => d.taskId === item?.taskId)
+			if (newItem?.id !== item?.id) {
+				onChangeSelectedItem(newItem?.id)
+			}
+		}
+		setLatestList(data)
+	}, [data])
 
 	const handleAxisClick = useCallback(
 		(datum: any, axis: string) => {


### PR DESCRIPTION
- 3d/2d reduced line width and opacity 
- disable deci inference sliders
- when receiving new specification data and one is selected, we now update the selected id accordingly with the new ordered list