### PR TITLE
Fix git end of line for scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 *.json text eol=lf
 *.yml text eol=lf
 *.md text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
## Issue
When the project is directly cloned on Windows, scripts will have `CRLF` as end of line, causing the docker build to fail.

## Fix
Update git attributes file to include `.sh` scripts, so the line ending is kept `LF` after the project is cloned.