### PR TITLE
Discover backend/frontend updates and fixes for DECI

### DIFF
--- a/javascript/app-discover/src/ProfilePlugin.tsx
+++ b/javascript/app-discover/src/ProfilePlugin.tsx
@@ -20,12 +20,14 @@ import { GraphViewStates } from './components/graph/GraphViews.types.js'
 import type { DECIParams } from './domain/Algorithms/DECI.js'
 import { CausalDiscoveryAlgorithm } from './domain/CausalDiscovery/CausalDiscoveryAlgorithm.js'
 import type { CausalDiscoveryConstraints } from './domain/CausalDiscovery/CausalDiscoveryConstraints.js'
+import type { CausalDiscoveryNormalization } from './domain/CausalDiscovery/CausalDiscoveryNormalization.js'
 import type { CausalDiscoveryResult } from './domain/CausalDiscovery/CausalDiscoveryResult.js'
 import { EMPTY_CAUSAL_DISCOVERY_RESULT } from './domain/CausalDiscovery/CausalDiscoveryResult.js'
 import type { Intervention } from './domain/CausalInference.js'
 import type { NodePosition } from './domain/NodePosition.js'
 import { DeciParamsState } from './state/atoms/algorithms_params.js'
 import {
+	CausalDiscoveryNormalizationState,
 	CausalDiscoveryResultsState,
 	CausalGraphConstraintsState,
 	CausalInferenceBaselineValuesState,
@@ -113,6 +115,7 @@ interface DiscoveryResourceSchema extends ResourceSchema {
 		confidenceThreshold: number
 		correlationThreshold: number
 		view: GraphViewStates
+		normalization: CausalDiscoveryNormalization
 		deciParams: DECIParams
 	}
 }
@@ -159,6 +162,7 @@ class DiscoveryResource extends Resource {
 		confidenceThreshold: number
 		correlationThreshold: number
 		view: GraphViewStates
+		normalization: CausalDiscoveryNormalization
 		deciParams: DECIParams
 	} = {
 		straightEdges: false,
@@ -168,6 +172,10 @@ class DiscoveryResource extends Resource {
 		confidenceThreshold: 0.5,
 		correlationThreshold: 0.2,
 		view: GraphViewStates.CausalView,
+		normalization: {
+			normalizeWithMeanEnabled: true,
+			normalizeWithStdEnabled: true,
+		},
 		deciParams: { model_options: {}, ate_options: {} },
 	}
 
@@ -241,6 +249,7 @@ function loadState(resource: DiscoveryResource, { set }: MutableSnapshot) {
 		FixedInterventionRangesEnabledState,
 		resource.ui.fixedInterventionRangesEnabled,
 	)
+	set(CausalDiscoveryNormalizationState, resource.ui.normalization)
 	set(
 		SelectedCausalDiscoveryAlgorithmState,
 		resource.ui.selectedDiscoveryAlgorithm,
@@ -274,6 +283,9 @@ function saveState(resource: DiscoveryResource, { getLoadable }: Snapshot) {
 	const fixedInterventionRangesEnabled = getLoadable(
 		FixedInterventionRangesEnabledState,
 	).getValue()
+	const normalization = getLoadable(
+		CausalDiscoveryNormalizationState,
+	).getValue()
 	const deciParams = getLoadable(DeciParamsState).getValue()
 	const selectedDiscoveryAlgorithm = getLoadable(
 		SelectedCausalDiscoveryAlgorithmState,
@@ -303,6 +315,7 @@ function saveState(resource: DiscoveryResource, { getLoadable }: Snapshot) {
 		confidenceThreshold,
 		correlationThreshold,
 		view,
+		normalization,
 		deciParams,
 	}
 }

--- a/javascript/app-discover/src/ProfilePlugin.tsx
+++ b/javascript/app-discover/src/ProfilePlugin.tsx
@@ -165,7 +165,7 @@ class DiscoveryResource extends Resource {
 		fixedInterventionRangesEnabled: false,
 		selectedDiscoveryAlgorithm: CausalDiscoveryAlgorithm.NOTEARS,
 		weightThreshold: 0.005,
-		confidenceThreshold: 0.0,
+		confidenceThreshold: 0.5,
 		correlationThreshold: 0.2,
 		view: GraphViewStates.CausalView,
 		deciParams: { model_options: {}, ate_options: {} },

--- a/javascript/app-discover/src/ProfilePlugin.tsx
+++ b/javascript/app-discover/src/ProfilePlugin.tsx
@@ -173,8 +173,8 @@ class DiscoveryResource extends Resource {
 		correlationThreshold: 0.2,
 		view: GraphViewStates.CausalView,
 		normalization: {
-			normalizeWithMeanEnabled: true,
-			normalizeWithStdEnabled: true,
+			withMeanEnabled: true,
+			withStdEnabled: true,
 		},
 		deciParams: { model_options: {}, ate_options: {} },
 	}

--- a/javascript/app-discover/src/components/AlgorithmControls.tsx
+++ b/javascript/app-discover/src/components/AlgorithmControls.tsx
@@ -15,6 +15,7 @@ import { Container, Section } from './AlgorithmControls.styles.js'
 import { Divider } from './controls/Divider.js'
 import { DeciParams } from './DeciParams.js'
 import { GraphFilteringControls } from './GraphFilteringControls.js'
+import { NormalizationControls } from './NormalizationControls.js'
 
 export const AlgorithmControls = memo(function AlgorithmControls() {
 	const [
@@ -47,6 +48,10 @@ export const AlgorithmControls = memo(function AlgorithmControls() {
 			<Section>
 				<Divider>Graph filtering</Divider>
 				<GraphFilteringControls />
+			</Section>
+			<Section>
+				<Divider>Normalization</Divider>
+				<NormalizationControls />
 			</Section>
 			<When
 				condition={

--- a/javascript/app-discover/src/components/DeciModelParams.constants.ts
+++ b/javascript/app-discover/src/components/DeciModelParams.constants.ts
@@ -16,7 +16,7 @@ import {
 	VarDistAMode,
 } from '../domain/Algorithms/DECI.js'
 
-const SPLINE_BINS = 16
+const SPLINE_BINS = 8
 const LAMBDA_DAG = 100.0
 const LAMBDA_SPARSE = 5.0
 const TAU_GUMBEL = 1.0
@@ -25,10 +25,10 @@ const IMPUTER_LAYER_SIZES: number[] = []
 const ENCODER_LAYER_SIZES = [32, 32]
 const DECODER_LAYER_SIZES = [32, 32]
 const IMPUTATION = false
-const NORM_LAYERS = false
+const NORM_LAYERS = true
 const RES_CONNECTION = true
 
-export const BASE_DISTRIBUTION_TYPE = BaseDistributionType.Gaussian
+export const BASE_DISTRIBUTION_TYPE = BaseDistributionType.Spline
 export const VAR_DIST_A_MODE = VarDistAMode.Three
 export const MODE_ADJACENCY = ModeAdjacency.Learn
 

--- a/javascript/app-discover/src/components/DeciTrainingParams.constants.ts
+++ b/javascript/app-discover/src/components/DeciTrainingParams.constants.ts
@@ -12,15 +12,15 @@ import { upperFirst } from 'lodash'
 
 import { AnnealEntropy } from '../domain/Algorithms/DECI.js'
 
-const LEARNING_RATE_DEFAULT = 1e-3
-const BATCH_SIZE = 256
-const RHO = 1.0
+const LEARNING_RATE_DEFAULT = 3e-2
+const BATCH_SIZE = 512
+const RHO = 10.0
 const SAFETY_RHO = 1e13
 const ALPHA = 0.0
 const SAFETY_ALPHA = 1e13
 const TOL_DAG = 1e-3
 const PROGRESS_RATE = 0.25
-const MAX_P_TRAIN_DROUPOUT = 0.25
+const MAX_P_TRAIN_DROPOUT = 0.25
 const RECONSTRUCTION_LOSS_FACTOR = 1.0
 const STANDARDIZE_DATA_MEAN = false
 const STANDARDIZE_DATA_STD = false
@@ -41,7 +41,7 @@ export const advancedTrainingSpinningOptions = [
 	},
 	{
 		label: 'Max p train dropout',
-		defaultValue: MAX_P_TRAIN_DROUPOUT,
+		defaultValue: MAX_P_TRAIN_DROPOUT,
 		inputProps: { name: 'max_p_train_dropout' },
 		step: 0.1,
 	},

--- a/javascript/app-discover/src/components/NormalizationControls.styles.ts
+++ b/javascript/app-discover/src/components/NormalizationControls.styles.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import styled from 'styled-components'
+
+export const NormalizationControlsContainer = styled.div`
+	padding-top: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+`

--- a/javascript/app-discover/src/components/NormalizationControls.tsx
+++ b/javascript/app-discover/src/components/NormalizationControls.tsx
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { Checkbox } from '@fluentui/react'
+import { memo } from 'react'
+import { useRecoilState } from 'recoil'
+
+import { CausalDiscoveryNormalizationState } from '../state/index.js'
+import { NormalizationControlsContainer } from './NormalizationControls.styles.js'
+
+export const NormalizationControls = memo(function NormalizationControls() {
+	const [causalDiscoveryNormalization, setCausalDiscoveryNormalization] =
+		useRecoilState(CausalDiscoveryNormalizationState)
+
+	return (
+		<NormalizationControlsContainer>
+			<Checkbox
+				label="Normalize with mean"
+				checked={causalDiscoveryNormalization.normalizeWithMeanEnabled}
+				onChange={(_, v) =>
+					setCausalDiscoveryNormalization(prev => ({
+						...prev,
+						normalizeWithMeanEnabled: Boolean(v),
+					}))
+				}
+			/>
+			<Checkbox
+				label="Normalize with standard deviation"
+				checked={causalDiscoveryNormalization.normalizeWithStdEnabled}
+				onChange={(_, v) =>
+					setCausalDiscoveryNormalization(prev => ({
+						...prev,
+						normalizeWithStdEnabled: Boolean(v),
+					}))
+				}
+			/>
+		</NormalizationControlsContainer>
+	)
+})

--- a/javascript/app-discover/src/components/NormalizationControls.tsx
+++ b/javascript/app-discover/src/components/NormalizationControls.tsx
@@ -17,21 +17,21 @@ export const NormalizationControls = memo(function NormalizationControls() {
 		<NormalizationControlsContainer>
 			<Checkbox
 				label="Normalize with mean"
-				checked={causalDiscoveryNormalization.normalizeWithMeanEnabled}
+				checked={causalDiscoveryNormalization.withMeanEnabled}
 				onChange={(_, v) =>
 					setCausalDiscoveryNormalization(prev => ({
 						...prev,
-						normalizeWithMeanEnabled: Boolean(v),
+						withMeanEnabled: Boolean(v),
 					}))
 				}
 			/>
 			<Checkbox
 				label="Normalize with standard deviation"
-				checked={causalDiscoveryNormalization.normalizeWithStdEnabled}
+				checked={causalDiscoveryNormalization.withStdEnabled}
 				onChange={(_, v) =>
 					setCausalDiscoveryNormalization(prev => ({
 						...prev,
-						normalizeWithStdEnabled: Boolean(v),
+						withStdEnabled: Boolean(v),
 					}))
 				}
 			/>

--- a/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
+++ b/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { useXarrow, Xwrapper } from 'react-xarrows'
 import {
 	useRecoilState,
@@ -158,9 +158,7 @@ export const CausalGraphExplorer: React.FC<{
 
 	const deselect = () => setSelectedObject(undefined)
 
-	const legendHeight = useMemo((): any => {
-		return legendRef?.current?.clientHeight ?? 0
-	}, [])
+	const legendHeight = legendRef?.current?.clientHeight ?? 0
 
 	// TODO: Figure out pan/zoom
 	return (

--- a/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
+++ b/javascript/app-discover/src/components/graph/CausalGraphExplorer.tsx
@@ -160,7 +160,7 @@ export const CausalGraphExplorer: React.FC<{
 
 	const legendHeight = useMemo((): any => {
 		return legendRef?.current?.clientHeight ?? 0
-	}, [legendRef?.current?.clientHeight])
+	}, [])
 
 	// TODO: Figure out pan/zoom
 	return (

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
@@ -16,6 +16,7 @@ import { CancelablePromise } from '../../utils/CancelablePromise.js'
 import type { DECIParams } from '../Algorithms/DECI.js'
 import { CausalDiscoveryAlgorithm } from './CausalDiscoveryAlgorithm.js'
 import type { CausalDiscoveryConstraints } from './CausalDiscoveryConstraints.js'
+import type { CausalDiscoveryNormalization } from './CausalDiscoveryNormalization.js'
 import type {
 	CausalDiscoveryRequestReturnValue,
 	CausalDiscoveryResult,
@@ -102,6 +103,7 @@ export function discover(
 	variables: CausalVariable[],
 	constraints: CausalDiscoveryConstraints,
 	algorithmName: CausalDiscoveryAlgorithm,
+	normalization: CausalDiscoveryNormalization,
 	progressCallback?: DiscoverProgressCallback,
 	paramOptions?: DECIParams,
 ): CausalDiscoveryResultPromise {
@@ -122,6 +124,10 @@ export function discover(
 				name: v.name,
 				nature: v.nature,
 			})),
+			normalization: {
+				normalize_with_mean: normalization.normalizeWithMeanEnabled,
+				normalize_with_std: normalization.normalizeWithStdEnabled,
+			},
 			...paramOptions,
 		}),
 		progressCallback,

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscovery.tsx
@@ -125,8 +125,8 @@ export function discover(
 				nature: v.nature,
 			})),
 			normalization: {
-				normalize_with_mean: normalization.normalizeWithMeanEnabled,
-				normalize_with_std: normalization.normalizeWithStdEnabled,
+				with_mean: normalization.withMeanEnabled,
+				with_std: normalization.withStdEnabled,
 			},
 			...paramOptions,
 		}),

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryNormalization.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryNormalization.tsx
@@ -3,6 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 export interface CausalDiscoveryNormalization {
-	normalizeWithMeanEnabled: boolean
-	normalizeWithStdEnabled: boolean
+	withMeanEnabled: boolean
+	withStdEnabled: boolean
 }

--- a/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryNormalization.tsx
+++ b/javascript/app-discover/src/domain/CausalDiscovery/CausalDiscoveryNormalization.tsx
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+export interface CausalDiscoveryNormalization {
+	normalizeWithMeanEnabled: boolean
+	normalizeWithStdEnabled: boolean
+}

--- a/javascript/app-discover/src/state/atoms/ui.ts
+++ b/javascript/app-discover/src/state/atoms/ui.ts
@@ -38,7 +38,7 @@ export const FixedInterventionRangesEnabledState = atom<boolean>({
 export const CausalDiscoveryNormalizationState =
 	atom<CausalDiscoveryNormalization>({
 		key: 'CausalDiscoveryNormalizationState',
-		default: { normalizeWithMeanEnabled: true, normalizeWithStdEnabled: true },
+		default: { withMeanEnabled: true, withStdEnabled: true },
 	})
 
 export const SelectedCausalDiscoveryAlgorithmState =

--- a/javascript/app-discover/src/state/atoms/ui.ts
+++ b/javascript/app-discover/src/state/atoms/ui.ts
@@ -7,6 +7,7 @@ import { atom } from 'recoil'
 
 import { GraphViewStates } from '../../components/graph/GraphViews.types.js'
 import { CausalDiscoveryAlgorithm } from '../../domain/CausalDiscovery/CausalDiscoveryAlgorithm.js'
+import type { CausalDiscoveryNormalization } from '../../domain/CausalDiscovery/CausalDiscoveryNormalization.js'
 import type { Selectable } from '../../domain/Selection.js'
 
 export const ErrorMessageState = atom<string | undefined>({
@@ -33,6 +34,12 @@ export const FixedInterventionRangesEnabledState = atom<boolean>({
 	key: 'FixedInterventionRangesEnabledState',
 	default: true,
 })
+
+export const CausalDiscoveryNormalizationState =
+	atom<CausalDiscoveryNormalization>({
+		key: 'CausalDiscoveryNormalizationState',
+		default: { normalizeWithMeanEnabled: true, normalizeWithStdEnabled: true },
+	})
 
 export const SelectedCausalDiscoveryAlgorithmState =
 	atom<CausalDiscoveryAlgorithm>({

--- a/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
+++ b/javascript/app-discover/src/state/hooks/useCausalDiscoveryRunner.ts
@@ -14,6 +14,7 @@ import { empty_discover_result } from '../../domain/CausalDiscovery/CausalDiscov
 import { CanceledPromiseError } from '../../utils/CancelablePromise.js'
 import {
 	AutoRunState,
+	CausalDiscoveryNormalizationState,
 	CausalDiscoveryResultsState,
 	CausalGraphConstraintsState,
 	DEFAULT_DATASET_NAME,
@@ -40,6 +41,7 @@ export function useCausalDiscoveryRunner() {
 	const causalDiscoveryAlgorithm = useRecoilValue(
 		SelectedCausalDiscoveryAlgorithmState,
 	)
+	const normalization = useRecoilValue(CausalDiscoveryNormalizationState)
 	const [autoRun, setAutoRun] = useRecoilState(AutoRunState)
 	const [isLoading, setIsLoading] = useRecoilState(IsDiscoverRunning)
 	const setCausalDiscoveryResultsState = useSetRecoilState(
@@ -93,6 +95,7 @@ export function useCausalDiscoveryRunner() {
 			inModelCausalVariables,
 			causalDiscoveryConstraints,
 			causalDiscoveryAlgorithm,
+			normalization,
 			updateProgress,
 			algorithmParams,
 		)
@@ -125,6 +128,7 @@ export function useCausalDiscoveryRunner() {
 		}
 	}, [
 		dataset,
+		normalization,
 		createDiscoveryPromise,
 		inModelCausalVariables,
 		causalDiscoveryAlgorithm,

--- a/javascript/app-discover/src/state/hooks/useCreateDiscoveryPromise.ts
+++ b/javascript/app-discover/src/state/hooks/useCreateDiscoveryPromise.ts
@@ -9,6 +9,7 @@ import type { DECIParams } from '../../domain/Algorithms/DECI.js'
 import { discover } from '../../domain/CausalDiscovery/CausalDiscovery.js'
 import type { CausalDiscoveryAlgorithm } from '../../domain/CausalDiscovery/CausalDiscoveryAlgorithm.js'
 import type { CausalDiscoveryConstraints } from '../../domain/CausalDiscovery/CausalDiscoveryConstraints.js'
+import type { CausalDiscoveryNormalization } from '../../domain/CausalDiscovery/CausalDiscoveryNormalization.js'
 import type { CausalVariable } from '../../domain/CausalVariable.js'
 import type { Dataset } from '../../domain/Dataset.js'
 import type {
@@ -26,6 +27,7 @@ export function useCreateDiscoveryPromise(
 			variables: CausalVariable[],
 			constraints: CausalDiscoveryConstraints,
 			algorithmName: CausalDiscoveryAlgorithm,
+			normalization: CausalDiscoveryNormalization,
 			progressCallback?: DiscoverProgressCallback,
 			paramOptions?: DECIParams,
 		) => {
@@ -37,6 +39,7 @@ export function useCreateDiscoveryPromise(
 				variables,
 				constraints,
 				algorithmName,
+				normalization,
 				progressCallback,
 				paramOptions,
 			)

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -663,8 +663,8 @@
                 "correlationThreshold": 0.2,
                 "view": 0,
                 "normalization": {
-                    "normalizeWithMeanEnabled": true,
-                    "normalizeWithStdEnabled": true
+                    "withMeanEnabled": true,
+                    "withStdEnabled": true
                 }
             }
         },

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -656,12 +656,16 @@
             },
             "ui": {
                 "straightEdges": false,
-                "fixedInterventionRangesEnabled": true,
+                "fixedInterventionRangesEnabled": false,
                 "selectedDiscoveryAlgorithm": "NOTEARS",
                 "weightThreshold": 0,
                 "confidenceThreshold": 0.5,
                 "correlationThreshold": 0.2,
-                "view": 0
+                "view": 0,
+                "normalization": {
+                    "normalizeWithMeanEnabled": true,
+                    "normalizeWithStdEnabled": true
+                }
             }
         },
         {

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -659,7 +659,7 @@
                 "fixedInterventionRangesEnabled": true,
                 "selectedDiscoveryAlgorithm": "NOTEARS",
                 "weightThreshold": 0,
-                "confidenceThreshold": 0.11,
+                "confidenceThreshold": 0.5,
                 "correlationThreshold": 0.2,
                 "view": 0
             }

--- a/python/backend/backend/discover/algorithms/commons/base_runner.py
+++ b/python/backend/backend/discover/algorithms/commons/base_runner.py
@@ -24,6 +24,7 @@ class CausalDiscoveryRunner(ABC):
         self, p: CausalDiscoveryPayload, progress_callback: ProgressCallback = None
     ):
         self._dataset_data = p.dataset.data
+        self._normalization = p.normalization
         self._constraints = p.constraints
         self._progress_callback = progress_callback
         self._nature_by_variable = {v.name: v.nature for v in p.causal_variables}
@@ -58,13 +59,17 @@ class CausalDiscoveryRunner(ABC):
             ]
 
             if continuous_columns:
-                logging.info(
-                    f"Scaling continuous columns {continuous_columns} using mean and standard deviation"
-                )
-
-                self._prepared_data[continuous_columns] = StandardScaler(
-                    with_mean=True, with_std=True
-                ).fit_transform(self._prepared_data[continuous_columns])
+                if (
+                    self._normalization.normalize_with_mean
+                    or self._normalization.normalize_with_std
+                ):
+                    logging.info(
+                        f"Scaling continuous columns {continuous_columns} using mean={self._normalization.normalize_with_mean} and standard deviation={self._normalization.normalize_with_std}"
+                    )
+                    self._prepared_data[continuous_columns] = StandardScaler(
+                        with_mean=self._normalization.normalize_with_mean,
+                        with_std=self._normalization.normalize_with_std,
+                    ).fit_transform(self._prepared_data[continuous_columns])
 
                 self._normalized_columns_metadata = {
                     column: NormalizedColumnMetadata(

--- a/python/backend/backend/discover/algorithms/commons/base_runner.py
+++ b/python/backend/backend/discover/algorithms/commons/base_runner.py
@@ -59,16 +59,13 @@ class CausalDiscoveryRunner(ABC):
             ]
 
             if continuous_columns:
-                if (
-                    self._normalization.normalize_with_mean
-                    or self._normalization.normalize_with_std
-                ):
+                if self._normalization.with_mean or self._normalization.with_std:
                     logging.info(
-                        f"Scaling continuous columns {continuous_columns} using mean={self._normalization.normalize_with_mean} and standard deviation={self._normalization.normalize_with_std}"
+                        f"Scaling continuous columns {continuous_columns} using mean={self._normalization.with_mean} and standard deviation={self._normalization.with_std}"
                     )
                     self._prepared_data[continuous_columns] = StandardScaler(
-                        with_mean=self._normalization.normalize_with_mean,
-                        with_std=self._normalization.normalize_with_std,
+                        with_mean=self._normalization.with_mean,
+                        with_std=self._normalization.with_std,
                     ).fit_transform(self._prepared_data[continuous_columns])
 
                 self._normalized_columns_metadata = {

--- a/python/backend/backend/discover/algorithms/commons/base_runner.py
+++ b/python/backend/backend/discover/algorithms/commons/base_runner.py
@@ -88,8 +88,7 @@ class CausalDiscoveryRunner(ABC):
             self._number_of_rows - self._prepared_data.shape[0]
         )
 
-    def _transform_categorical_nominal_to_continuous(self):
-        # TODO: remove this once categorical values are properly handled by each algorithm
+    def _encode_categorical_as_integers(self):
         for name in self._prepared_data.columns:
             if (
                 self._nature_by_variable[name]

--- a/python/backend/backend/discover/algorithms/deci.py
+++ b/python/backend/backend/discover/algorithms/deci.py
@@ -184,14 +184,11 @@ class DeciRunner(CausalDiscoveryRunner):
         return constraint.astype(np.float32)
 
     def _check_if_is_dag(self, deci_model: DECI, adj_matrix: np.ndarray) -> bool:
-        return (np.trace(scipy.linalg.expm(adj_matrix)) - deci_model.num_nodes) == 0
+        return (
+            np.trace(scipy.linalg.expm(adj_matrix.round())) - deci_model.num_nodes
+        ) == 0
 
     def _get_adj_matrix(self, deci_model: DECI) -> np.ndarray:
-        # The next lines of code are the same as:
-        # deci_graph = deci_model.networkx_graph()
-        # but omit an assertion that the graph is a DAG.  This is so the calculation doesn't just
-        # fail after 20 minutes due to a single bad edge.
-        # TODO
         adj_matrix = deci_model.get_adj_matrix(
             do_round=False,
             samples=1,

--- a/python/backend/backend/discover/algorithms/deci.py
+++ b/python/backend/backend/discover/algorithms/deci.py
@@ -34,8 +34,8 @@ ATE_CALC_PROGRESS_PROPORTION = 0.3
 
 # TODO: UPDATE DEFAULTS
 class DeciModelOptions(BaseModel):
-    base_distribution_type: Literal["gaussian", "spline"] = "gaussian"
-    spline_bins: int = 16
+    base_distribution_type: Literal["gaussian", "spline"] = "spline"
+    spline_bins: int = 8
     imputation: bool = False
     lambda_dag: float = 100.0
     lambda_sparse: float = 5.0
@@ -43,7 +43,7 @@ class DeciModelOptions(BaseModel):
     var_dist_A_mode: Literal["simple", "enco", "true", "three"] = "three"
     imputer_layer_sizes: Optional[List[int]] = None
     mode_adjacency: Literal["upper", "lower", "learn"] = "learn"
-    norm_layers: bool = False
+    norm_layers: bool = True
     res_connection: bool = True
     encoder_layer_sizes: Optional[List[int]] = [32, 32]
     decoder_layer_sizes: Optional[List[int]] = [32, 32]
@@ -58,11 +58,11 @@ class DeciModelOptions(BaseModel):
 #  decreasing max_auglag_inner_epochs
 # TODO: UPDATE DEFAULTS
 class DeciTrainingOptions(BaseModel):
-    learning_rate: float = 1e-3
-    batch_size: int = 256
+    learning_rate: float = 3e-2
+    batch_size: int = 512
     standardize_data_mean: bool = False
     standardize_data_std: bool = False
-    rho: float = 1.0
+    rho: float = 10.0
     safety_rho: float = 1e13
     alpha: float = 0.0
     safety_alpha: float = 1e13

--- a/python/backend/backend/discover/algorithms/deci.py
+++ b/python/backend/backend/discover/algorithms/deci.py
@@ -280,9 +280,6 @@ class DeciRunner(CausalDiscoveryRunner):
         ]
         causal_graph["confidence_matrix"] = adj_matrix.tolist()
         causal_graph["ate_matrix"] = ate_matrix.tolist()
-        # TODO: we should evaluate whether this is necessary to keep or not
-        #       in case we need to keep, reimplement it
-        causal_graph["interpret_boolean_as_continuous"] = False
         causal_graph["has_weights"] = True
         causal_graph["has_confidence_values"] = True
         causal_graph["is_dag"] = bool(self._is_dag)

--- a/python/backend/backend/discover/algorithms/interventions/deci.py
+++ b/python/backend/backend/discover/algorithms/interventions/deci.py
@@ -7,6 +7,7 @@ import torch
 from causica.models.deci.deci import DECI
 from celery import uuid
 
+from backend.discover.config import get_intervention_model_expires_after
 from backend.discover.model.interventions import (
     InterventionResult,
     InterventionValueByColumn,
@@ -137,7 +138,11 @@ class DeciInterventionModel:
 
     def save(self):
         db_client = get_db_client()
-        db_client.set_value(f"intervention_model:{self._id}", self)
+        db_client.set_value(
+            f"intervention_model:{self._id}",
+            self,
+            expire_after=get_intervention_model_expires_after(),
+        )
 
     @staticmethod
     def load(intervention_model_id: str):

--- a/python/backend/backend/discover/algorithms/interventions/deci.py
+++ b/python/backend/backend/discover/algorithms/interventions/deci.py
@@ -60,8 +60,8 @@ class DeciInterventionModel:
 
     def _parse_raw_result(self, raw_result: np.ndarray) -> InterventionValueByColumn:
         return {
-            var.name: float(raw_result[:, i].mean())
-            for i, var in enumerate(self._deci_model.variables)
+            var_name: float(raw_result[:, idx].mean())
+            for var_name, idx in self._deci_model.variables.name_to_idx.items()
         }
 
     def _map_interventions(

--- a/python/backend/backend/discover/algorithms/interventions/deci.py
+++ b/python/backend/backend/discover/algorithms/interventions/deci.py
@@ -49,14 +49,14 @@ class DeciInterventionModel:
             for j in range(n_cols):
                 if (
                     confidence_threshold is not None
-                    and abs(self._adj_matrix[i][j]) < confidence_threshold
+                    and abs(self._adj_matrix[i][j]) <= confidence_threshold
                 ) or (
                     weight_threshold is not None
-                    and abs(self._ate_matrix[i][j]) < weight_threshold
+                    and abs(self._ate_matrix[i][j]) <= weight_threshold
                 ):
                     adj_matrix[i][j] = 0
 
-        return torch.from_numpy(adj_matrix).float().to(self._deci_model.device)
+        return torch.from_numpy(adj_matrix.round()).float().to(self._deci_model.device)
 
     def _parse_raw_result(self, raw_result: np.ndarray) -> InterventionValueByColumn:
         return {
@@ -75,9 +75,7 @@ class DeciInterventionModel:
         for name, value in interventions.items():
             idx = self._deci_model.variables.name_to_idx[name]
             if idx is not None:
-                interventions_by_index[
-                    self._deci_model.variables.name_to_idx[name]
-                ] = value
+                interventions_by_index[idx] = value
             else:
                 logging.warning(
                     f"Intervention column {name} ignored: column name not found"

--- a/python/backend/backend/discover/algorithms/interventions/deci.py
+++ b/python/backend/backend/discover/algorithms/interventions/deci.py
@@ -40,24 +40,11 @@ class DeciInterventionModel:
     ):
         adj_matrix = self._adj_matrix.copy()
 
-        n_lines, n_cols = adj_matrix.shape
+        if confidence_threshold is not None and confidence_threshold > 0:
+            adj_matrix[abs(self._adj_matrix) <= confidence_threshold] = 0
 
-        if confidence_threshold is None:
-            confidence_threshold = 0
-
-        if weight_threshold is None:
-            weight_threshold = 0
-
-        for i in range(n_lines):
-            for j in range(n_cols):
-                if (
-                    confidence_threshold > 0
-                    and abs(self._adj_matrix[i][j]) <= confidence_threshold
-                ) or (
-                    weight_threshold > 0
-                    and abs(self._ate_matrix[i][j]) <= weight_threshold
-                ):
-                    adj_matrix[i][j] = 0
+        if weight_threshold is not None and weight_threshold > 0:
+            adj_matrix[abs(self._ate_matrix) <= weight_threshold] = 0
 
         return adj_matrix
 

--- a/python/backend/backend/discover/algorithms/interventions/deci.py
+++ b/python/backend/backend/discover/algorithms/interventions/deci.py
@@ -49,9 +49,11 @@ class DeciInterventionModel:
             for j in range(n_cols):
                 if (
                     confidence_threshold is not None
+                    and confidence_threshold > 0
                     and abs(self._adj_matrix[i][j]) <= confidence_threshold
                 ) or (
                     weight_threshold is not None
+                    and weight_threshold > 0
                     and abs(self._ate_matrix[i][j]) <= weight_threshold
                 ):
                     adj_matrix[i][j] = 0

--- a/python/backend/backend/discover/algorithms/notears.py
+++ b/python/backend/backend/discover/algorithms/notears.py
@@ -20,7 +20,7 @@ class NotearsRunner(CausalDiscoveryRunner):
         super().__init__(p, progress_callback)
 
     def do_causal_discovery(self) -> CausalGraph:
-        self._transform_categorical_nominal_to_continuous()
+        self._encode_categorical_as_integers()
 
         notears_graph = from_pandas(
             self._prepared_data,

--- a/python/backend/backend/discover/algorithms/pc.py
+++ b/python/backend/backend/discover/algorithms/pc.py
@@ -23,7 +23,7 @@ class PCRunner(CausalDiscoveryRunner):
         super().__init__(p, progress_callback)
 
     def do_causal_discovery(self) -> CausalGraph:
-        self._transform_categorical_nominal_to_continuous()
+        self._encode_categorical_as_integers()
 
         n = PC(alpha=0.2)
         n.learn(self._prepared_data.to_numpy())

--- a/python/backend/backend/discover/config.py
+++ b/python/backend/backend/discover/config.py
@@ -1,0 +1,11 @@
+import logging
+import os
+
+
+def get_intervention_model_expires_after():
+    storage_location = os.environ.get("INTERVENTION_MODEL_EXPIRES_AFTER")
+    if storage_location:
+        return int(storage_location)
+    else:
+        logging.info("using default of 8 hours for INTERVENTION_MODEL_EXPIRES_AFTER")
+        return 24 * 60 * 60

--- a/python/backend/backend/discover/model/causal_discovery.py
+++ b/python/backend/backend/discover/model/causal_discovery.py
@@ -29,8 +29,8 @@ class Dataset(BaseModel):
 
 
 class NormalizationOptions(BaseModel):
-    normalize_with_mean: bool = True
-    normalize_with_std: bool = True
+    with_mean: bool = True
+    with_std: bool = True
 
 
 class CausalDiscoveryPayload(BaseModel):

--- a/python/backend/backend/discover/model/causal_discovery.py
+++ b/python/backend/backend/discover/model/causal_discovery.py
@@ -50,10 +50,10 @@ class DatasetStatistics(BaseModel):
 
 
 _causal_var_nature_to_causica_var_type = {
-    "Discrete": "continuous",  # TODO: make categorical (related to ONNX)
+    "Discrete": "continuous",  # TODO: make categorical
     "Continuous": "continuous",
-    "Categorical Ordinal": "continuous",  # TODO: make categorical (related to ONNX)
-    "Categorical Nominal": "continuous",  # TODO: make categorical (related to ONNX)
+    "Categorical Ordinal": "continuous",  # TODO: make categorical
+    "Categorical Nominal": "continuous",  # TODO: make categorical
     "Binary": "binary",
     "Excluded": "continuous",
 }

--- a/python/backend/backend/discover/model/causal_discovery.py
+++ b/python/backend/backend/discover/model/causal_discovery.py
@@ -28,8 +28,14 @@ class Dataset(BaseModel):
     data: Dict[str, List[Any]]
 
 
+class NormalizationOptions(BaseModel):
+    normalize_with_mean: bool = True
+    normalize_with_std: bool = True
+
+
 class CausalDiscoveryPayload(BaseModel):
     dataset: Dataset
+    normalization: NormalizationOptions = NormalizationOptions()
     constraints: Constraints
     causal_variables: List[CausalVariable]
 

--- a/python/backend/backend/worker_commons/io/db.py
+++ b/python/backend/backend/worker_commons/io/db.py
@@ -5,10 +5,11 @@
 
 import pickle
 from abc import ABC, abstractmethod
-from typing import Any, Iterator
+from typing import Any, Iterator, Union
 from urllib.parse import urlparse
 
 import redis
+from redis.typing import ExpiryT
 
 from backend.worker_commons import config
 
@@ -41,8 +42,10 @@ class RedisDB(Storage):
     def iter_values(self, pattern: str) -> Iterator[Any]:
         return self.client.scan_iter(f"{pattern}*")
 
-    def set_value(self, key: str, value: Any) -> None:
-        self.client.set(key, pickle.dumps(value))
+    def set_value(
+        self, key: str, value: Any, expire_after: Union[ExpiryT, None] = None
+    ) -> None:
+        self.client.set(key, pickle.dumps(value), ex=expire_after)
 
 
 def get_db_client():


### PR DESCRIPTION
### Updates and fixes
- cleanup `onnx` export not used in the backend anymore
- updating DECI default parameters (slower to run but produces more accurate results)
- fix DAG detection in the backend
- updating default `confidenceThreshold` to 0.5
- update DECI backend to use `name_to_idx` from `causica`
- remove unused `interpret_boolean_as_continuous` from DECI backend
- round filtered adjacency matrix for DECI interventions backend
- updating mean/std normalization of continuous variables to be optional on discover
- updating ATE calculation on discover backend and preparing code to handle categorical variables
- DECI intervention backend updates
- updating interventions backend to properly handle thresholds
- updating interventions threshold filtering to use `numpy`
- apply discover app linting suggestions
- configuring intervention model to expire after some time on redis