### PR TITLE
Fix onehot bug by adding correct table codebook

### DIFF
--- a/javascript/app-discover/src/domain/Dataset.tsx
+++ b/javascript/app-discover/src/domain/Dataset.tsx
@@ -106,7 +106,6 @@ export function useDatasetLoader() {
 function useWorkflow(table: TableContainer | undefined): Workflow {
 	const steps = useDataProcessingSteps()
 	return useMemo<Workflow>(() => {
-		console.log("new wf")
 		const res = new Workflow()
 		res.input$ = from([table])
 		steps.forEach(s => res.addStep(s))
@@ -124,6 +123,7 @@ function useDataProcessingSteps(): StepInput[] {
 				metadatum.min != null &&
 				metadatum.max != null
 			) {
+				console.log(metadatum)
 				const step = {
 					verb: Verb.Onehot,
 					args: {
@@ -132,11 +132,7 @@ function useDataProcessingSteps(): StepInput[] {
 						preserveSource: true,
 					},
 				}
-				console.log('not applying new step', step)
-				//
-				// TODO: this last-mile one-hot encoding is causing browser hangs. Not sure what's up.
-				//
-				// result.push(step)
+				result.push(step)
 			}
 		})
 		return result

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -15,6 +15,335 @@
                     }
                 },
                 {
+					"$schema": "https://microsoft.github.io/datashaper/schema/codebook/v1.0.0.json",
+					"id": "afe1c7d9-0f3e-44cb-9e22-6c3c6ff24427",
+					"name": "Codebook",
+					"profile": "codebook",
+					"title": "codebook.json",
+					"fields": [
+					  {
+						"name": "seqn",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "qsmk",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "death",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "yrdth",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "modth",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "dadth",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "sbp",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "dbp",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "sex",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "age",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "race",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "income",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "marital",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "school",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "education",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "ht",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "wt71",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "wt82",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "wt82_71",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "birthplace",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "smokeintensity",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "smkintensity82_71",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "smokeyrs",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "asthma",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "bronch",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "tb",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "hf",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "hbp",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "pepticulcer",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "colitis",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "hepatitis",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "chroniccough",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "hayfever",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "diabetes",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "polio",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "tumor",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "nervousbreak",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "alcoholpy",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "alcoholfreq",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "alcoholtype",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "alcoholhowmuch",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "pica",
+						"type": "number",
+						"nature": "ordinal"
+					  },
+					  {
+						"name": "headache",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "otherpain",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "weakheart",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "allergies",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "nerves",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "lackpep",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "hbpmed",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "boweltrouble",
+						"type": "number",
+						"nature": "ordinal"
+					  },
+					  {
+						"name": "wtloss",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "infection",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "active",
+						"type": "number",
+						"nature": "ordinal"
+					  },
+					  {
+						"name": "exercise",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "birthcontrol",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "pregnancies",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "cholesterol",
+						"type": "number",
+						"nature": "discrete"
+					  },
+					  {
+						"name": "hightax82",
+						"type": "number",
+						"nature": "binary"
+					  },
+					  {
+						"name": "price71",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "price82",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "tax71",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "tax82",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "price71_82",
+						"type": "number",
+						"nature": "continuous"
+					  },
+					  {
+						"name": "tax71_82",
+						"type": "number",
+						"nature": "continuous"
+					  }
+					]
+				  },
+                {
                     "profile": "workflow",
                     "steps": [
                         {


### PR DESCRIPTION
Addresses an issue where CauseDis would hang when loading the smoking example after the latest DataShaper update. This was caused by changes that default DS table loading to not apply types unless a codebook is present, so all columns were being assigned a nature of "categorical nominal" and therefore getting a onehot applied - which created massive amounts of new columns and hung the app.

- Adds a codebook to the example table, so it is correctly typed
- Restores the auto-onehot in CauseDis