### PR TITLE
Fix example dataset urls

### DIFF
--- a/.yarn/versions/e1023165.yml
+++ b/.yarn/versions/e1023165.yml
@@ -1,0 +1,2 @@
+declined:
+  - showwhy

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This interface allows users to inspect variable relationships within data, and t
 
 **Note: At the moment, ShowWhy does not work with Apple Mxx processors in local mode.**
 
-To run the application locally,ensure that you have Docker installed and running on your machine. You can find instructions for installing Docker [here](https://docs.docker.com/get-docker/).
+To run the application locally, ensure that you have Docker installed and running on your machine. You can find instructions for installing Docker [here](https://docs.docker.com/get-docker/).
 
 Open up a terminal application, and using the command-line interface (CLI) run the following command:
 

--- a/javascript/webapp/public/data/examples/smoking.json
+++ b/javascript/webapp/public/data/examples/smoking.json
@@ -8,7 +8,7 @@
                 {
                     "rel": "input",
                     "profile": "datatable",
-                    "path": "https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv",
+                    "path": "https://microsoft.github.io/datashaper/data/NHEFS.csv",
                     "metadata": {
                         "source": "https://www.hsph.harvard.edu/miguel-hernan/causal-inference-book/",
                         "citation": "Hernán MA, Robins JM (2020). Causal Inference: What If. Boca Raton: Chapman & Hall/CRC"
@@ -614,7 +614,7 @@
                 {
                     "rel": "input",
                     "profile": "datatable",
-                    "path": "https://cdn.jsdelivr.net/gh/synth-inference/synthdid@master/data/california_prop99.csv",
+                    "path": "https://microsoft.github.io/datashaper/data/california_prop99.csv",
                     "metadata": {
                         "source": "https://www.openicpsr.org/openicpsr/project/146381/version/V1/view?path=/openicpsr/146381/fcr:versions/V1/synthdid-sdid-paper/data/california_prop99.csv",
                         "citation": " Dmitry Arkhangelsky, CEMFI; Susan Athey, Stanford University; David A. Hirshberg, Emory University; Guido W. Imbens, Stanford University; Stefan Wager, Stanford University"


### PR DESCRIPTION
Sets the NHEFS and prop99 urls to our deployed DataShaper location for stability